### PR TITLE
gcs: Vendor jstarks/virtsock to fix vsock fd leak

### DIFF
--- a/vendor/github.com/linuxkit/virtsock/pkg/vsock/fallback.go
+++ b/vendor/github.com/linuxkit/virtsock/pkg/vsock/fallback.go
@@ -14,11 +14,11 @@ func SocketMode(socketMode string) {
 }
 
 // Dial is the unimplemented fallback for unsupported OSes
-func Dial(cid, port uint) (Conn, error) {
+func Dial(cid, port uint32) (Conn, error) {
 	return nil, fmt.Errorf("Unimplemented")
 }
 
 // Listen is the unimplemented fallback for unsupported OSes
-func Listen(cid, port uint) (net.Listener, error) {
+func Listen(cid, port uint32) (net.Listener, error) {
 	return nil, fmt.Errorf("Unimplemented")
 }

--- a/vendor/github.com/linuxkit/virtsock/pkg/vsock/hyperkit_darwin.go
+++ b/vendor/github.com/linuxkit/virtsock/pkg/vsock/hyperkit_darwin.go
@@ -27,14 +27,13 @@ var (
 // ("hyperkit:/path") or Docker for Mac mode ("docker"). This function
 // must be called before using the vsock bindings.
 func SocketMode(socketMode string) {
+	connectPath = filepath.Join(socketPath, "connect")
+	socketFmt = "%08x.%08x"
+
 	if strings.HasPrefix(socketMode, "hyperkit:") {
 		socketPath = socketMode[len("hyperkit:"):]
-		connectPath = filepath.Join(socketPath, "connect")
-		socketFmt = "%08x.%08x"
 	} else if socketMode == "docker" {
 		socketPath = filepath.Join(os.Getenv("HOME"), "/Library/Containers/com.docker.docker/Data")
-		connectPath = filepath.Join(socketPath, "@connect")
-		socketFmt = "*%08x.%08x"
 	} else {
 		log.Fatalln("Unknown socket mode: ", socketMode)
 	}

--- a/vendor/github.com/linuxkit/virtsock/pkg/vsock/vsock.go
+++ b/vendor/github.com/linuxkit/virtsock/pkg/vsock/vsock.go
@@ -12,6 +12,7 @@
 package vsock
 
 import (
+	"fmt"
 	"net"
 )
 
@@ -23,6 +24,22 @@ const (
 	// CIDHost is the reserved CID for the host system
 	CIDHost = 2
 )
+
+// VsockAddr represents the address of a vsock end point.
+type VsockAddr struct {
+	CID  uint32
+	Port uint32
+}
+
+// Network returns the network type for a VsockAddr
+func (a VsockAddr) Network() string {
+	return "vsock"
+}
+
+// String returns a string representation of a VsockAddr
+func (a VsockAddr) String() string {
+	return fmt.Sprintf("%08x.%08x", a.CID, a.Port)
+}
 
 // Conn is a vsock connection which supports half-close.
 type Conn interface {

--- a/vendor/github.com/linuxkit/virtsock/pkg/vsock/vsock_linux.go
+++ b/vendor/github.com/linuxkit/virtsock/pkg/vsock/vsock_linux.go
@@ -16,22 +16,6 @@ import (
 func SocketMode(m string) {
 }
 
-// VsockAddr represents the address of a vsock end point.
-type VsockAddr struct {
-	CID  uint32
-	Port uint32
-}
-
-// Network returns the network type for a VsockAddr
-func (a VsockAddr) Network() string {
-	return "vsock"
-}
-
-// String returns a string representation of a VsockAddr
-func (a VsockAddr) String() string {
-	return fmt.Sprintf("%08x.%08x", a.CID, a.Port)
-}
-
 // Convert a generic unix.Sockaddr to a VsockAddr
 func sockaddrToVsock(sa unix.Sockaddr) *VsockAddr {
 	switch sa := sa.(type) {
@@ -43,7 +27,7 @@ func sockaddrToVsock(sa unix.Sockaddr) *VsockAddr {
 
 // Dial connects to the CID.Port via virtio sockets
 func Dial(cid, port uint32) (Conn, error) {
-	fd, err := syscall.Socket(unix.AF_VSOCK, syscall.SOCK_STREAM, 0)
+	fd, err := syscall.Socket(unix.AF_VSOCK, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +48,7 @@ func Dial(cid, port uint32) (Conn, error) {
 
 // Listen returns a net.Listener which can accept connections on the given port
 func Listen(cid, port uint32) (net.Listener, error) {
-	fd, err := syscall.Socket(unix.AF_VSOCK, syscall.SOCK_STREAM, 0)
+	fd, err := syscall.Socket(unix.AF_VSOCK, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -117,10 +117,13 @@
 			"revisionTime": "2017-06-20T23:04:58Z"
 		},
 		{
-			"checksumSHA1": "iBAbi93jlnfHF7n0XJQz9akeZe8=",
+			"checksumSHA1": "gMvxdRRwh9lrEElBYXtcH/ODD38=",
+			"origin": "github.com/jstarks/virtsock/pkg/vsock",
 			"path": "github.com/linuxkit/virtsock/pkg/vsock",
-			"revision": "762e85c7c864a294224becbcfaf73c5750bca82f",
-			"revisionTime": "2017-07-03T12:58:29Z"
+			"revision": "8673ecb0ac8910dd64e91bc042fbf4b2377f2358",
+			"revisionTime": "2017-07-07T00:40:52Z",
+			"version": "vsock_cloexec",
+			"versionExact": "vsock_cloexec"
 		},
 		{
 			"checksumSHA1": "3yckDt/xIreJZ/spvI+MvHOCmcY=",


### PR DESCRIPTION
This vendors a virtsock fix in so that child processes do not
inherit all vsock fds when they are launched.