### PR TITLE
Make go binaries using a private pkg directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 
 # Ignore gcs bin directory
 service/bin/
+service/pkg/

--- a/service/Makefile
+++ b/service/Makefile
@@ -13,14 +13,12 @@ GCS_TOOLS=\
 	createSandbox \
 	exportSandbox
 
-# For now, disable optimizations to improve debugging.
-GO_FLAGS=-gcflags "-N -l"
+GO_FLAGS=-pkgdir "$(WORKDIR)/pkg"
 
 all: gobins
 
 gobins:
 	(cd $(WORKDIR) && GOBIN="$(BINDIR)" CGO_ENABLED=0 go install $(GO_FLAGS) $(GO_PACKAGES))
-#	mv "$(BINDIR)/gogcs" "$(BINDIR)/gcs" # Fix name for gcs until the directory name changes
 	(cd $(BINDIR) && $(foreach tool,$(GCS_TOOLS), ln -f "gcstools" "$(tool)";))
 
 clean:


### PR DESCRIPTION
When CGO_ENABLED is set to 0, go needs to rebuild its runtime without
cgo support. This requires write access to GOROOT, which the user often
does not have.

Since this is the non-default configuration, the best thing to do is to
store the pkg cache locally so that Go does not try to overwrite any
existing packages built with CGO_ENABLED=1.

This also requires removing the -N -l flags from go, since building the
go runtime with these flags set often fails.