### PR TITLE
Support embedding HRESULT codes in errors

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/Microsoft/opengcs/service/gcs/core"
+	gcserr "github.com/Microsoft/opengcs/service/gcs/errors"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/transport"
@@ -182,7 +183,7 @@ func (b *bridge) loop() error {
 func (b *bridge) createContainer(message []byte) (*prot.ContainerCreateResponse, error) {
 	response := &prot.ContainerCreateResponse{MessageResponseBase: newResponseBase()}
 	var request prot.ContainerCreate
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON in message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -190,7 +191,7 @@ func (b *bridge) createContainer(message []byte) (*prot.ContainerCreateResponse,
 	// The request contains a JSON string field which is equivalent to a
 	// CreateContainerInfo struct.
 	var settings prot.VMHostedContainerSettings
-	if err := json.Unmarshal([]byte(request.ContainerConfig), &settings); err != nil {
+	if err := utils.UnmarshalJSONWithHresult([]byte(request.ContainerConfig), &settings); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for ContainerConfig \"%s\"", request.ContainerConfig)
 	}
 
@@ -215,13 +216,13 @@ func (b *bridge) createContainer(message []byte) (*prot.ContainerCreateResponse,
 func (b *bridge) execProcess(message []byte) (*prot.ContainerExecuteProcessResponse, error) {
 	response := &prot.ContainerExecuteProcessResponse{MessageResponseBase: newResponseBase()}
 	var request prot.ContainerExecuteProcess
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	// The request contains a JSON string field which is equivalent to an
 	// ExecuteProcessInfo struct.
 	var params prot.ProcessParameters
-	if err := json.Unmarshal([]byte(request.Settings.ProcessParameters), &params); err != nil {
+	if err := utils.UnmarshalJSONWithHresult([]byte(request.Settings.ProcessParameters), &params); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for ProcessParameters \"%s\"", request.Settings.ProcessParameters)
 	}
 
@@ -271,7 +272,7 @@ func (b *bridge) execProcess(message []byte) (*prot.ContainerExecuteProcessRespo
 func (b *bridge) killContainer(message []byte) (*prot.MessageResponseBase, error) {
 	response := newResponseBase()
 	var request prot.MessageBase
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -286,7 +287,7 @@ func (b *bridge) killContainer(message []byte) (*prot.MessageResponseBase, error
 func (b *bridge) shutdownContainer(message []byte) (*prot.MessageResponseBase, error) {
 	response := newResponseBase()
 	var request prot.MessageBase
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -301,7 +302,7 @@ func (b *bridge) shutdownContainer(message []byte) (*prot.MessageResponseBase, e
 func (b *bridge) terminateProcess(message []byte) (*prot.MessageResponseBase, error) {
 	response := newResponseBase()
 	var request prot.ContainerTerminateProcess
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -316,7 +317,7 @@ func (b *bridge) terminateProcess(message []byte) (*prot.MessageResponseBase, er
 func (b *bridge) listProcesses(message []byte) (*prot.ContainerGetPropertiesResponse, error) {
 	response := &prot.ContainerGetPropertiesResponse{MessageResponseBase: newResponseBase()}
 	var request prot.ContainerGetProperties
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -338,7 +339,7 @@ func (b *bridge) listProcesses(message []byte) (*prot.ContainerGetPropertiesResp
 func (b *bridge) runExternalProcess(message []byte) (*prot.ContainerExecuteProcessResponse, error) {
 	response := &prot.ContainerExecuteProcessResponse{MessageResponseBase: newResponseBase()}
 	var request prot.ContainerExecuteProcess
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -346,7 +347,7 @@ func (b *bridge) runExternalProcess(message []byte) (*prot.ContainerExecuteProce
 	// The request contains a JSON string field which is equivalent to a
 	// RunExternalProcessInfo struct.
 	var params prot.ProcessParameters
-	if err := json.Unmarshal([]byte(request.Settings.ProcessParameters), &params); err != nil {
+	if err := utils.UnmarshalJSONWithHresult([]byte(request.Settings.ProcessParameters), &params); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for ProcessParameters \"%s\"", request.Settings.ProcessParameters)
 	}
 
@@ -371,7 +372,7 @@ func (b *bridge) runExternalProcess(message []byte) (*prot.ContainerExecuteProce
 func (b *bridge) waitOnProcess(message []byte, header *prot.MessageHeader) (*prot.ContainerWaitForProcessResponse, error) {
 	response := &prot.ContainerWaitForProcessResponse{MessageResponseBase: newResponseBase()}
 	var request prot.ContainerWaitForProcess
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -394,7 +395,7 @@ func (b *bridge) waitOnProcess(message []byte, header *prot.MessageHeader) (*pro
 func (b *bridge) resizeConsole(message []byte) (*prot.MessageResponseBase, error) {
 	response := newResponseBase()
 	var request prot.ContainerResizeConsole
-	if err := json.Unmarshal(message, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
@@ -430,19 +431,14 @@ func newResponseBase() *prot.MessageResponseBase {
 // setErrorForResponseBase modifies the passed-in MessageResponseBase to
 // contain information pertaining to the given error.
 func (b *bridge) setErrorForResponseBase(response *prot.MessageResponseBase, errForResponse error) {
-	// stackTracer must be defined to access the stack trace of the error. I'm
-	// not totally sure why it isn't just exported by the errors package.
-	type stackTracer interface {
-		StackTrace() errors.StackTrace
-	}
 	errorMessage := errForResponse.Error()
 	fileName := ""
 	lineNumber := -1
 	functionName := ""
-	if errForResponse, ok := errForResponse.(stackTracer); ok {
-		frames := errForResponse.StackTrace()
+	if serr, ok := errForResponse.(gcserr.StackTracer); ok {
+		frames := serr.StackTrace()
 		bottomFrame := frames[0]
-		errorMessage = fmt.Sprintf("%+v", errForResponse)
+		errorMessage = fmt.Sprintf("%+v", serr)
 		fileName = fmt.Sprintf("%s", bottomFrame)
 		lineNumberStr := fmt.Sprintf("%d", bottomFrame)
 		var err error
@@ -453,9 +449,14 @@ func (b *bridge) setErrorForResponseBase(response *prot.MessageResponseBase, err
 		}
 		functionName = fmt.Sprintf("%n", bottomFrame)
 	}
-	response.Result = -2147467259
+	hresult, err := gcserr.GetHresult(errForResponse)
+	if err != nil {
+		// Default to using the generic failure HRESULT.
+		hresult = gcserr.HrFail
+	}
+	response.Result = int32(hresult)
 	newRecord := prot.ErrorRecord{
-		Result:       -2147467259,
+		Result:       int32(hresult),
 		Message:      errorMessage,
 		ModuleName:   "gcs",
 		FileName:     fileName,

--- a/service/gcs/errors/errors.go
+++ b/service/gcs/errors/errors.go
@@ -1,7 +1,24 @@
-package gcs
+package errors
 
 import (
 	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+// Hresult is a type corresponding to the HRESULT error type used on Windows.
+type Hresult int32
+
+const (
+	HrUnexpected   = Hresult(-2147418113) // 0x8000FFFF
+	HrNotImpl      = Hresult(-2147467263) // 0x80004001
+	HrInvalidArg   = Hresult(-2147024809) // 0x80070057
+	HrPointer      = Hresult(-2147467261) // 0x80004003
+	HrFail         = Hresult(-2147467259) // 0x80004005
+	HrAccessDenied = Hresult(-2147024891) // 0x80070005
+
+	HrVmcomputeInvalidJSON = Hresult(-1070137075) // 0xC037010D
 )
 
 type containerExistsError struct {
@@ -44,4 +61,102 @@ func (e *processDoesNotExistError) Error() string {
 // the given pid.
 func NewProcessDoesNotExistError(pid int) *processDoesNotExistError {
 	return &processDoesNotExistError{Pid: pid}
+}
+
+// StackTracer is an interface originating (but not exported) from the
+// github.com/pkg/errors package. It defines something which can return a stack
+// trace.
+type StackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+type baseHresultError struct {
+	hresult Hresult
+}
+
+func (e *baseHresultError) Error() string {
+	return fmt.Sprintf("HRESULT: 0x%x", uint32(e.Hresult()))
+}
+func (e *baseHresultError) Hresult() Hresult {
+	return e.hresult
+}
+
+type wrappingHresultError struct {
+	cause   error
+	hresult Hresult
+}
+
+func (e *wrappingHresultError) Error() string {
+	return fmt.Sprintf("HRESULT 0x%x", uint32(e.Hresult())) + ": " + e.Cause().Error()
+}
+func (e *wrappingHresultError) Hresult() Hresult {
+	return e.hresult
+}
+func (e *wrappingHresultError) Cause() error {
+	return e.cause
+}
+func (e *wrappingHresultError) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", e.Cause())
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, e.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", e.Error())
+	}
+}
+func (e *wrappingHresultError) StackTrace() errors.StackTrace {
+	type stackTracer interface {
+		StackTrace() errors.StackTrace
+	}
+	serr, ok := e.Cause().(stackTracer)
+	if !ok {
+		return nil
+	}
+	return serr.StackTrace()
+}
+
+// NewHresultError produces a new error with the given HRESULT.
+func NewHresultError(hresult Hresult) error {
+	return &baseHresultError{hresult: hresult}
+}
+
+// WrapHresult produces a new error with the given HRESULT and wrapping the
+// given error.
+func WrapHresult(e error, hresult Hresult) error {
+	return &wrappingHresultError{
+		cause:   e,
+		hresult: hresult,
+	}
+}
+
+// GetHresult interates through the error's cause stack (similiarly to how the
+// Cause function in github.com/pkg/errors operates). At the first error it
+// encounters which implements the Hresult() method, it return's that error's
+// HRESULT. This allows errors higher up in the cause stack to shadow the
+// HRESULTs of errors lower down.
+func GetHresult(e error) (Hresult, error) {
+	type hresulter interface {
+		Hresult() Hresult
+	}
+	type causer interface {
+		Cause() error
+	}
+	cause := e
+	for cause != nil {
+		herr, ok := cause.(hresulter)
+		if ok {
+			return herr.Hresult(), nil
+		}
+		cerr, ok := cause.(causer)
+		if !ok {
+			break
+		}
+		cause = cerr.Cause()
+	}
+	return -1, errors.Errorf("no HRESULT found in cause stack for error %s", e)
 }

--- a/service/gcs/errors/errors_suite_test.go
+++ b/service/gcs/errors/errors_suite_test.go
@@ -1,0 +1,13 @@
+package errors
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestErrors(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Errors Suite")
+}

--- a/service/gcs/errors/errors_test.go
+++ b/service/gcs/errors/errors_test.go
@@ -1,0 +1,175 @@
+package errors
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type stackTraceError interface {
+	error
+	StackTrace() errors.StackTrace
+}
+type causeError interface {
+	error
+	Cause() error
+}
+type stackTraceCauseError interface {
+	stackTraceError
+	Cause() error
+}
+
+var _ = Describe("Errors", func() {
+	Describe("unittests", func() {
+		Describe("constructing HRESULT errors", func() {
+			Context("with no wrapped error", func() {
+				var (
+					herr *baseHresultError
+				)
+				BeforeEach(func() {
+					e := NewHresultError(HrInvalidArg)
+					var ok bool
+					herr, ok = e.(*baseHresultError)
+					Expect(ok).To(BeTrue())
+				})
+				It("should have the correct HRESULT value", func() {
+					Expect(herr.Hresult()).To(Equal(HrInvalidArg))
+				})
+				It("should have the correct error string", func() {
+					Expect(herr.Error()).To(Equal("HRESULT: 0x80070057"))
+				})
+			})
+			Context("with a wrapped errorString", func() {
+				var (
+					herr       *wrappingHresultError
+					wrappedErr error
+				)
+				BeforeEach(func() {
+					wrappedErr = fmt.Errorf("wrapped %s", "error")
+					e := WrapHresult(wrappedErr, HrInvalidArg)
+					var ok bool
+					herr, ok = e.(*wrappingHresultError)
+					Expect(ok).To(BeTrue())
+				})
+				It("should have the correct HRESULT value", func() {
+					Expect(herr.Hresult()).To(Equal(HrInvalidArg))
+				})
+				It("should have a cause equal to wrappedErr", func() {
+					Expect(herr.Cause()).To(Equal(wrappedErr))
+				})
+				It("should have an error string equal to that of wrappedErr", func() {
+					Expect(herr.Error()).To(Equal("HRESULT 0x80070057: " + wrappedErr.Error()))
+				})
+				It("should have a nil stack trace", func() {
+					Expect(herr.StackTrace()).To(BeNil())
+				})
+			})
+			Context("with a wrapped pkg/errors error", func() {
+				var (
+					herr       *wrappingHresultError
+					wrappedErr stackTraceError
+				)
+				BeforeEach(func() {
+					e1 := errors.New("wrapped error")
+					var ok bool
+					wrappedErr, ok = e1.(stackTraceError)
+					Expect(ok).To(BeTrue())
+					e2 := WrapHresult(wrappedErr, HrInvalidArg)
+					herr, ok = e2.(*wrappingHresultError)
+					Expect(ok).To(BeTrue())
+				})
+				It("should have the correct HRESULT value", func() {
+					Expect(herr.Hresult()).To(Equal(HrInvalidArg))
+				})
+				It("should have a cause equal to wrappedErr", func() {
+					Expect(herr.Cause()).To(Equal(wrappedErr))
+				})
+				It("should have a stack trace equal to that of wrappedErr", func() {
+					Expect(herr.StackTrace()).To(Equal(wrappedErr.StackTrace()))
+				})
+				It("should have an error string equal to that of wrappedErr", func() {
+					Expect(herr.Error()).To(Equal("HRESULT 0x80070057: " + wrappedErr.Error()))
+				})
+			})
+		})
+		Describe("creating cause stacks", func() {
+			Context("baseHresultError is direct cause", func() {
+				var (
+					herr   *baseHresultError
+					pkgErr causeError
+				)
+				BeforeEach(func() {
+					e1 := NewHresultError(HrInvalidArg)
+					var ok bool
+					herr, ok = e1.(*baseHresultError)
+					Expect(ok).To(BeTrue())
+					e2 := errors.Wrap(herr, "stackErr")
+					pkgErr, ok = e2.(causeError)
+					Expect(ok).To(BeTrue())
+				})
+				It("should have the correct HRESULT value", func() {
+					Expect(GetHresult(pkgErr)).To(Equal(HrInvalidArg))
+				})
+				It("should have herr as its cause", func() {
+					Expect(errors.Cause(pkgErr)).To(Equal(herr))
+				})
+			})
+			Context("wrappingHresultError is direct cause", func() {
+				var (
+					wrappedErr error
+					herr       *wrappingHresultError
+					pkgErr     causeError
+				)
+				BeforeEach(func() {
+					wrappedErr = errors.New("wrapped error")
+					e1 := WrapHresult(wrappedErr, HrInvalidArg)
+					var ok bool
+					herr, ok = e1.(*wrappingHresultError)
+					Expect(ok).To(BeTrue())
+					e2 := errors.Wrap(herr, "pkgErr")
+					pkgErr, ok = e2.(causeError)
+					Expect(ok).To(BeTrue())
+				})
+				It("should have the correct HRESULT value", func() {
+					Expect(GetHresult(pkgErr)).To(Equal(HrInvalidArg))
+				})
+				It("should have wrappedErr as its cause", func() {
+					Expect(errors.Cause(pkgErr)).To(Equal(wrappedErr))
+				})
+			})
+			Context("multiple HRESULT errors in the cause stack", func() {
+				var (
+					wrappedErr error
+					herr1      *wrappingHresultError
+					herr2      *wrappingHresultError
+					pkgErr     stackTraceCauseError
+				)
+				BeforeEach(func() {
+					wrappedErr = errors.New("wrapped error")
+					e1 := WrapHresult(wrappedErr, HrInvalidArg)
+					var ok bool
+					herr1, ok = e1.(*wrappingHresultError)
+					Expect(ok).To(BeTrue())
+					e2 := errors.Wrap(herr1, "pkgErr")
+					pkgErr, ok = e2.(stackTraceCauseError)
+					Expect(ok).To(BeTrue())
+					e3 := WrapHresult(pkgErr, HrNotImpl)
+					herr2, ok = e3.(*wrappingHresultError)
+					Expect(ok).To(BeTrue())
+				})
+				It("should have the correct HRESULT value", func() {
+					Expect(GetHresult(herr2)).To(Equal(HrNotImpl))
+				})
+				It("should have wrappedErr as its cause", func() {
+					Expect(errors.Cause(pkgErr)).To(Equal(wrappedErr))
+				})
+				It("should have the same stack as pkgErr", func() {
+					Expect(herr2.StackTrace()).To(Equal(pkgErr.StackTrace()))
+				})
+			})
+		})
+	})
+})

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -8,6 +8,8 @@ import (
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+
+	"github.com/Microsoft/opengcs/service/libs/commonutils"
 )
 
 //////////// Code for the Message Header ////////////
@@ -300,7 +302,7 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 	var request ContainerModifySettings
 	var rawSettings json.RawMessage
 	request.Request.Settings = &rawSettings
-	if err := json.Unmarshal(b, &request); err != nil {
+	if err := utils.UnmarshalJSONWithHresult(b, &request); err != nil {
 		return nil, errors.WithStack(err)
 	}
 
@@ -317,7 +319,7 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 	switch request.Request.ResourceType {
 	case PtMappedVirtualDisk:
 		settings.MappedVirtualDisk = &MappedVirtualDisk{}
-		if err := json.Unmarshal(rawSettings, settings.MappedVirtualDisk); err != nil {
+		if err := utils.UnmarshalJSONWithHresult(rawSettings, settings.MappedVirtualDisk); err != nil {
 			return nil, errors.Wrap(err, "failed to unmarshal settings as MappedVirtualDisk")
 		}
 		request.Request.Settings = settings

--- a/service/gcs/runtime/runc/runc.go
+++ b/service/gcs/runtime/runc/runc.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/realos"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
+	"github.com/Microsoft/opengcs/service/libs/commonutils"
 )
 
 const (
@@ -442,7 +443,7 @@ func (r *runcRuntime) hasTerminal(bundlePath string) (bool, error) {
 	}
 	defer configFile.Close()
 	var config oci.Spec
-	if err := json.NewDecoder(configFile).Decode(&config); err != nil {
+	if err := utils.DecodeJSONWithHresult(configFile, &config); err != nil {
 		return false, errors.Wrap(err, "failed to decode config file as JSON")
 	}
 	return config.Process.Terminal, nil
@@ -462,7 +463,7 @@ func (c *container) runExecCommand(processDef oci.Process, stdioOptions runtime.
 	}
 	defer f.Close()
 	if err := json.NewEncoder(f).Encode(processDef); err != nil {
-		return nil, errors.Wrap(err, "failed to decode JSON from process.json file")
+		return nil, errors.Wrap(err, "failed to encode JSON into process.json file")
 	}
 
 	args := []string{"exec"}


### PR DESCRIPTION
This allows the GCS to return HRESULTs to the HCS for certain errors.
HRESULTs are a common way for the HCS to represent errors.

This change only adds HRESULTs to JSON parsing errors at the moment. It
is mostly focused on building the necessary infrastructure. Additional
HRESULTs can be added now as needed.