### PR TITLE
Fix issue in runC tests where container list not initialized

### DIFF
--- a/service/gcs/runtime/runc/runc_test.go
+++ b/service/gcs/runtime/runc/runc_test.go
@@ -163,6 +163,8 @@ var _ = Describe("runC", func() {
 		bundle, err = getBundlePath()
 		Expect(err).NotTo(HaveOccurred())
 
+		containers = nil
+
 		createAllStdioOptions = runtime.StdioOptions{
 			CreateIn:  true,
 			CreateOut: true,


### PR DESCRIPTION
This caused the list to leak between tests, resulting in data races and
test failures.