### PR TITLE
Updated patches with previsouly missing Signed-off-by line

### DIFF
--- a/kernelconfig/4.11/patch_9pfs_vsock-transport.patch
+++ b/kernelconfig/4.11/patch_9pfs_vsock-transport.patch
@@ -3,6 +3,8 @@ From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Tue, 27 Jun 2017 20:04:44 -0700
 Subject: [PATCH] Added vsock transport support to 9pfs
 
+Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>
+
 ---
  net/9p/trans_fd.c | 77 ++++++++++++++++++++++++++++++++++++++++++++++++++++++-
  1 file changed, 76 insertions(+), 1 deletion(-)

--- a/kernelconfig/4.11/patch_lower-the-minimum-PMEM-size.patch
+++ b/kernelconfig/4.11/patch_lower-the-minimum-PMEM-size.patch
@@ -3,6 +3,8 @@ From: Cheng-mean Liu <soccerl@microsoft.com>
 Date: Fri, 30 Jun 2017 16:14:03 -0700
 Subject: [PATCH] lower the minimum PMEM size
 
+Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>
+
 ---
  include/uapi/linux/ndctl.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -16,7 +18,7 @@ index ede5c6a..6f17246 100644
  
  enum {
 -	ND_MIN_NAMESPACE_SIZE = 0x00400000,
-+	ND_MIN_NAMESPACE_SIZE = 0x00040000, // 256 KB
++	ND_MIN_NAMESPACE_SIZE = 0x00001000, // 4 KB
  };
  
  enum ars_masks {


### PR DESCRIPTION
for patch_9pfs_vsock-transport.patch and patch_lower-the-minimum-PMEM-size.patch