### PR TITLE
Updated patches with previsouly missing Signed-off-by line

### DIFF
--- a/kernelconfig/4.11/patch_9pfs_vsock-transport.patch
+++ b/kernelconfig/4.11/patch_9pfs_vsock-transport.patch
@@ -1,30 +1,29 @@
-From cbce811777331869e4b2ef3b5cc04de0dc9a0d05 Mon Sep 17 00:00:00 2001
+From de027707cf6aa72f54e9cc4617b2ba3d044f85e3 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
-Date: Tue, 27 Jun 2017 20:04:44 -0700
+Date: Tue, 11 Jul 2017 16:50:36 -0700
 Subject: [PATCH] Added vsock transport support to 9pfs
 
+Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>
 ---
- net/9p/trans_fd.c | 77 ++++++++++++++++++++++++++++++++++++++++++++++++++++++-
- 1 file changed, 76 insertions(+), 1 deletion(-)
- mode change 100644 => 100755 net/9p/trans_fd.c
+ net/9p/trans_fd.c | 85 ++++++++++++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 84 insertions(+), 1 deletion(-)
 
 diff --git a/net/9p/trans_fd.c b/net/9p/trans_fd.c
-old mode 100644
-new mode 100755
-index 7bc2208..bd28173
+index 7bc2208..dc34352 100644
 --- a/net/9p/trans_fd.c
 +++ b/net/9p/trans_fd.c
-@@ -44,8 +44,8 @@
+@@ -44,8 +44,9 @@
  #include <net/9p/9p.h>
  #include <net/9p/client.h>
  #include <net/9p/transport.h>
 -
  #include <linux/syscalls.h> /* killme */
++//#include <linux/kgdb.h>
 +#include <linux/vm_sockets.h>
  
  #define P9_PORT 564
  #define MAX_SOCK_BUF (64*1024)
-@@ -155,6 +155,7 @@ struct p9_trans_fd {
+@@ -155,6 +156,7 @@ struct p9_trans_fd {
  	struct p9_conn conn;
  };
  
@@ -32,7 +31,7 @@ index 7bc2208..bd28173
  static void p9_poll_workfn(struct work_struct *work);
  
  static DEFINE_SPINLOCK(p9_poll_lock);
-@@ -740,6 +741,7 @@ static int parse_opts(char *params, struct p9_fd_opts *opts)
+@@ -740,6 +742,7 @@ static int parse_opts(char *params, struct p9_fd_opts *opts)
  	opts->wfd = ~0;
  	opts->privport = 0;
  
@@ -40,7 +39,7 @@ index 7bc2208..bd28173
  	if (!params)
  		return 0;
  
-@@ -1035,6 +1037,65 @@ p9_fd_create(struct p9_client *client, const char *addr, char *args)
+@@ -1035,6 +1038,72 @@ p9_fd_create(struct p9_client *client, const char *addr, char *args)
  	return 0;
  }
  
@@ -58,7 +57,11 @@ index 7bc2208..bd28173
 +
 +	csocket = NULL;
 +
-+	// create socket
++	// for debugging purpose only
++        pr_err("%s:%s\n", __func__, addr);
++	// kgdb_breakpoint();
++
++        // create socket
 +	err = __sock_create(current->nsproxy->net_ns,
 +		                AF_VSOCK,
 +		                SOCK_STREAM,
@@ -74,39 +77,42 @@ index 7bc2208..bd28173
 +	memset((char *)&server_socket_addr, 0, sizeof(struct sockaddr_vm));
 +	server_socket_addr.svm_family = AF_VSOCK;
 +	server_socket_addr.svm_reserved1 = 0;
-+	server_socket_addr.svm_cid = VMADDR_CID_HOST;
++        server_socket_addr.svm_cid = VMADDR_CID_HOST;
 +
-+	/* Connecting to the host's 0000pppp-facb-11e6-bd58-64006a7986d3 */
++        /* Connecting to the host's 0000pppp-facb-11e6-bd58-64006a7986d3 */ 
 +	server_socket_addr.svm_port = opts.port;
-+	pr_err("%s:opts.port=(%d)(0x%x)\n", __func__, opts.port, opts.port);
-+	pr_err("%s: service_id:(hex) 0000%x%x-facb-11e6-bd58-64006a7986d3\n",
-+               __func__,
-+               (__u8)((opts.port & 0xff00) >> 8),
-+               (__u8)(opts.port & 0x00ff));
 +
-+	pr_err("%s: connecting", __func__);
++        pr_err("%s:opts.port=(%d)(0x%x)\n", __func__, opts.port, opts.port);
++        pr_err("%s: service_id:(hex) 0000%x%x-facb-11e6-bd58-64006a7986d3\n",
++                __func__, 
++                (__u8)((opts.port & 0xff00) >> 8),
++                (__u8)(opts.port & 0x00ff));
++
++        pr_err("%s: connecting", __func__);
 +	err = csocket->ops->connect(csocket,
-+                                    (struct sockaddr *)&server_socket_addr,
-+                                    sizeof(struct sockaddr_vm), 0);
++		                    (struct sockaddr *)&server_socket_addr,
++		                    sizeof(struct sockaddr_vm), 0);
 +	if (err < 0) {
 +		pr_err("%s:connect (%d): problem connecting socket to %s (err = %d)\n",
-+                       __func__, task_pid_nr(current), addr, err);
-+                sock_release(csocket);
-+                return err;
++			__func__, task_pid_nr(current), addr, err);
++		sock_release(csocket);
++		return err;
 +	}
 +
-+	err = p9_socket_open(client, csocket);
-+	if (err < 0) {
++        pr_err("%s: open socket", __func__);
++        err = p9_socket_open(client, csocket);
++        if (err < 0) {
 +            pr_err("%s: p9_socket_open failed\n", __func__);
-+	}
++         }
 +
++        pr_err("Leaving %s\n", __func__);
 +	return err;
 +}
 +
  static struct p9_trans_module p9_tcp_trans = {
  	.name = "tcp",
  	.maxsize = MAX_SOCK_BUF,
-@@ -1071,6 +1132,18 @@ static struct p9_trans_module p9_fd_trans = {
+@@ -1071,6 +1140,18 @@ static struct p9_trans_module p9_fd_trans = {
  	.owner = THIS_MODULE,
  };
  
@@ -125,7 +131,7 @@ index 7bc2208..bd28173
  /**
   * p9_poll_proc - poll worker thread
   * @a: thread state and arguments
-@@ -1108,6 +1181,7 @@ int p9_trans_fd_init(void)
+@@ -1108,6 +1189,7 @@ int p9_trans_fd_init(void)
  	v9fs_register_trans(&p9_tcp_trans);
  	v9fs_register_trans(&p9_unix_trans);
  	v9fs_register_trans(&p9_fd_trans);
@@ -133,7 +139,7 @@ index 7bc2208..bd28173
  
  	return 0;
  }
-@@ -1118,4 +1192,5 @@ void p9_trans_fd_exit(void)
+@@ -1118,4 +1200,5 @@ void p9_trans_fd_exit(void)
  	v9fs_unregister_trans(&p9_tcp_trans);
  	v9fs_unregister_trans(&p9_unix_trans);
  	v9fs_unregister_trans(&p9_fd_trans);

--- a/kernelconfig/4.11/patch_lower-the-minimum-PMEM-size.patch
+++ b/kernelconfig/4.11/patch_lower-the-minimum-PMEM-size.patch
@@ -1,14 +1,16 @@
-From 5b1cbb12216438c8c8e05c44f1e036eb184aef20 Mon Sep 17 00:00:00 2001
+From 78422de836ee3f76f42e0c93b657869f5e7103b3 Mon Sep 17 00:00:00 2001
 From: Cheng-mean Liu <soccerl@microsoft.com>
-Date: Fri, 30 Jun 2017 16:14:03 -0700
-Subject: [PATCH] lower the minimum PMEM size
+Date: Tue, 11 Jul 2017 16:58:26 -0700
+Subject: [PATCH] NVDIMM: reducded ND_MIN_NAMESPACE_SIZE from 4MB to 4KB (page
+ size)
 
+Signed-off-by: Cheng-mean Liu <soccerl@microsoft.com>
 ---
  include/uapi/linux/ndctl.h | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/uapi/linux/ndctl.h b/include/uapi/linux/ndctl.h
-index ede5c6a..6f17246 100644
+index ede5c6a..4776082 100644
 --- a/include/uapi/linux/ndctl.h
 +++ b/include/uapi/linux/ndctl.h
 @@ -259,7 +259,7 @@ enum nd_driver_flags {
@@ -16,7 +18,7 @@ index ede5c6a..6f17246 100644
  
  enum {
 -	ND_MIN_NAMESPACE_SIZE = 0x00400000,
-+	ND_MIN_NAMESPACE_SIZE = 0x00040000, // 256 KB
++	ND_MIN_NAMESPACE_SIZE = 0x00001000,
  };
  
  enum ars_masks {


### PR DESCRIPTION
For the following two files:
patch_9pfs_vsock-transport.patch
patch_lower-the-minimum-PMEM-size.patch