### PR TITLE
Add binaries used by docker

### DIFF
--- a/docs/customosbuildinstructions.md
+++ b/docs/customosbuildinstructions.md
@@ -81,7 +81,7 @@ Here are the expected contents of each subdirectory /file
        /lib/x86_64-linux-gnu/libuuid.so.1
        /lib/modules
 
-7. **/bin** : binaries in this subdir are categorised into three groups
+7. **/bin** : binaries in this subdir are categorised into four groups
         
     - [GCS binaries](gcsbuildinstructions.md/)
 
@@ -104,6 +104,12 @@ Here are the expected contents of each subdirectory /file
              /bin/ip
              /bin/iproute
              /bin/hostname
+
+    - Required binaires: utilities used by docker
+
+             /bin/ls
+             /bin/cat
+             /bin/test
 
     - Debugging tools: mostly from busybox tool set
        


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@soccerGB Adds the additional binaries not listed which docker needs. Note strictly mkfs.ext4 is shared and already in the list, but I didn't explicitly mention it was required by docker (for the dynamic sandbox management update shortly to be PR'd).