### PR TITLE
Added additional details on the build instructions

### DIFF
--- a/docs/customosbuildinstructions.md
+++ b/docs/customosbuildinstructions.md
@@ -49,7 +49,10 @@ Here are the expected contents of each subdirectory /file
    This is the [init script file](../kernelconfig/4.11/scripts/init_script)
 
 3. **/root** : this is the home directory of the root account. At this moment, it contains a sandbox file with a prebuilt empty ext4 fs for supporting Service VM operations
+         
          /root/integration/prebuildSandbox.vhdx
+
+         Note: this vhdx file could be found in opengcs/kernelconfig/4.11
 
 4. **/sbin** : 
     - /sbin/runc  
@@ -91,6 +94,8 @@ Here are the expected contents of each subdirectory /file
             /bin/tar2vhd
             /bin/exportSandbox
             /bin/createSandbox
+
+            Note : exportSandbox, createSandbox, vhd2tar, and tar2vhd  are actually hard links to the file gcstools
 
     - Required binaires: utilities used by gcs
 

--- a/docs/customosbuildinstructions.md
+++ b/docs/customosbuildinstructions.md
@@ -52,7 +52,7 @@ Here are the expected contents of each subdirectory /file
          
          /root/integration/prebuildSandbox.vhdx
 
-         Note: this vhdx file could be found in opengcs/kernelconfig/4.11
+         Note: this vhdx file is located under opengcs/kernelconfig/4.11 
 
 4. **/sbin** : 
     - /sbin/runc  


### PR DESCRIPTION
Added comment on where to find prebuildSandbox.vhdx
Added a note on the fact that exportSandbox, createSandbox, vhd2tar, and tar2vhd  are actually hard links to the file gcstools
