### PR TITLE
GCS log to gcs.log

### DIFF
--- a/kernelconfig/4.11/scripts/init_script
+++ b/kernelconfig/4.11/scripts/init_script
@@ -20,6 +20,6 @@ mount -t tmpfs shm /dev/shm
 
 # Run gcs in the background
 cd /bin
-./gcs  -loglevel=verbose -logfile=/tmp/gcslog.txt &
+./gcs  -loglevel=verbose -logfile=/tmp/gcs.log &
 cd -
 sh


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Consistency..... not `gcslog.txt`, `gcs.log`