### PR TITLE
General Cleanup

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -8,15 +8,14 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/Sirupsen/logrus"
-	"github.com/pkg/errors"
-
 	"github.com/Microsoft/opengcs/service/gcs/core"
 	gcserr "github.com/Microsoft/opengcs/service/gcs/errors"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/transport"
 	"github.com/Microsoft/opengcs/service/libs/commonutils"
+	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
 // bridge defines the bridge client in the GCS.

--- a/service/gcs/bridge/bridge_suite_test.go
+++ b/service/gcs/bridge/bridge_suite_test.go
@@ -1,10 +1,10 @@
 package bridge
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestBridge(t *testing.T) {

--- a/service/gcs/bridge/bridge_suite_test.go
+++ b/service/gcs/bridge/bridge_suite_test.go
@@ -1,13 +1,18 @@
 package bridge
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestBridge(t *testing.T) {
+	// Turn off logging so as not to spam output.
+	logrus.SetOutput(ioutil.Discard)
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Bridge Suite")
 }

--- a/service/gcs/bridge/bridge_test.go
+++ b/service/gcs/bridge/bridge_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Bridge", func() {
 	JustBeforeEach(func(done Done) {
 		defer close(done)
 
-		b := NewBridge(tport, coreint, false)
+		b := NewBridge(tport, coreint)
 		go func() {
 			defer GinkgoRecover()
 			b.CommandLoop()

--- a/service/gcs/bridge/bridge_test.go
+++ b/service/gcs/bridge/bridge_test.go
@@ -6,16 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/Microsoft/opengcs/service/gcs/core/mockcore"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/mockos"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/transport"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 const (

--- a/service/gcs/core/gcs/cleanup.go
+++ b/service/gcs/core/gcs/cleanup.go
@@ -1,11 +1,10 @@
 package gcs
 
 import (
-	"github.com/Sirupsen/logrus"
-
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
+	"github.com/Sirupsen/logrus"
 )
 
 // CleanupContainer cleans up the state left behind by the container with the

--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -11,16 +11,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
-	shellwords "github.com/mattn/go-shellwords"
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-
 	gcserr "github.com/Microsoft/opengcs/service/gcs/errors"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
+	"github.com/Sirupsen/logrus"
+	shellwords "github.com/mattn/go-shellwords"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/service/gcs/core/gcs/gcs_suite_test.go
+++ b/service/gcs/core/gcs/gcs_suite_test.go
@@ -1,10 +1,10 @@
 package gcs
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestGCS(t *testing.T) {

--- a/service/gcs/core/gcs/gcs_suite_test.go
+++ b/service/gcs/core/gcs/gcs_suite_test.go
@@ -1,13 +1,18 @@
 package gcs
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestGCS(t *testing.T) {
+	// Turn off logging so as not to spam output.
+	logrus.SetOutput(ioutil.Discard)
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "GCS Suite")
 }

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -3,16 +3,15 @@ package gcs
 import (
 	"fmt"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/mockos"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/runtime/mockruntime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 var _ = Describe("GCS", func() {

--- a/service/gcs/core/gcs/networking.go
+++ b/service/gcs/core/gcs/networking.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/pkg/errors"
-
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
+	"github.com/pkg/errors"
 )
 
 // instanceIDToName converts from the given instance ID (a GUID generated on

--- a/service/gcs/core/gcs/storage.go
+++ b/service/gcs/core/gcs/storage.go
@@ -11,11 +11,10 @@ import (
 	"syscall"
 	"time"
 
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Sirupsen/logrus"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/service/gcs/core/gcs/storage_test.go
+++ b/service/gcs/core/gcs/storage_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/realos"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime/runc"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/service/gcs/errors/errors_suite_test.go
+++ b/service/gcs/errors/errors_suite_test.go
@@ -1,13 +1,18 @@
 package errors
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestErrors(t *testing.T) {
+	// Turn off logging so as not to spam output.
+	logrus.SetOutput(ioutil.Discard)
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Errors Suite")
 }

--- a/service/gcs/errors/errors_suite_test.go
+++ b/service/gcs/errors/errors_suite_test.go
@@ -1,10 +1,10 @@
 package errors
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestErrors(t *testing.T) {

--- a/service/gcs/errors/errors_test.go
+++ b/service/gcs/errors/errors_test.go
@@ -3,10 +3,9 @@ package errors
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 )
 
 type stackTraceError interface {

--- a/service/gcs/main.go
+++ b/service/gcs/main.go
@@ -56,6 +56,6 @@ func main() {
 	}
 	os := realos.NewOS()
 	coreint := gcs.NewGCSCore(rtime, os)
-	b := bridge.NewBridge(tport, coreint, true)
+	b := bridge.NewBridge(tport, coreint)
 	b.CommandLoop()
 }

--- a/service/gcs/main.go
+++ b/service/gcs/main.go
@@ -5,14 +5,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/Sirupsen/logrus"
-
 	"github.com/Microsoft/opengcs/service/gcs/bridge"
 	"github.com/Microsoft/opengcs/service/gcs/core/gcs"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/realos"
 	"github.com/Microsoft/opengcs/service/gcs/runtime/runc"
 	"github.com/Microsoft/opengcs/service/gcs/transport"
 	"github.com/Microsoft/opengcs/service/libs/commonutils"
+	"github.com/Sirupsen/logrus"
 )
 
 func main() {

--- a/service/gcs/oslayer/realos/realos.go
+++ b/service/gcs/oslayer/realos/realos.go
@@ -11,11 +11,10 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/pkg/errors"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
-
-	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 )
 
 // realProcessExitState represents an oslayer.ProcessExitState which uses an

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -6,10 +6,9 @@ package prot
 import (
 	"encoding/json"
 
+	"github.com/Microsoft/opengcs/service/libs/commonutils"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-
-	"github.com/Microsoft/opengcs/service/libs/commonutils"
 )
 
 //////////// Code for the Message Header ////////////

--- a/service/gcs/runtime/mockruntime/mockruntime.go
+++ b/service/gcs/runtime/mockruntime/mockruntime.go
@@ -2,12 +2,11 @@
 package mockruntime
 
 import (
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/mockos"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // mockRuntime is an implementation of the Runtime interface which uses runC as

--- a/service/gcs/runtime/runc/runc.go
+++ b/service/gcs/runtime/runc/runc.go
@@ -12,15 +12,14 @@ import (
 	"strconv"
 	"strings"
 
-	containerdsys "github.com/docker/containerd/sys"
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
-
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/realos"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
 	"github.com/Microsoft/opengcs/service/libs/commonutils"
+	containerdsys "github.com/docker/containerd/sys"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
 )
 
 const (

--- a/service/gcs/runtime/runc/runc_suite_test.go
+++ b/service/gcs/runtime/runc/runc_suite_test.go
@@ -1,13 +1,18 @@
 package runc
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/Sirupsen/logrus"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestRunc(t *testing.T) {
+	// Turn off logging so as not to spam output.
+	logrus.SetOutput(ioutil.Discard)
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "RunC Suite")
 }

--- a/service/gcs/runtime/runc/runc_suite_test.go
+++ b/service/gcs/runtime/runc/runc_suite_test.go
@@ -1,10 +1,10 @@
 package runc
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"testing"
 )
 
 func TestRunc(t *testing.T) {

--- a/service/gcs/runtime/runc/runc_test.go
+++ b/service/gcs/runtime/runc/runc_test.go
@@ -6,13 +6,12 @@ import (
 	"os"
 	"path/filepath"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // globals for the whole test suite

--- a/service/gcs/runtime/runtime.go
+++ b/service/gcs/runtime/runtime.go
@@ -5,10 +5,9 @@ package runtime
 import (
 	"io"
 
-	oci "github.com/opencontainers/runtime-spec/specs-go"
-
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
 // ContainerState gives information about a container created by a Runtime.


### PR DESCRIPTION
Just some general cleanup work. Fixed all imports under service/gcs to use the format used by goimports, and removed the now unnecessary printErrors flag from the bridge code.