### PR TITLE
Fixed a gcs failure due to a logging switching to  logrus package 

### DIFF
--- a/kernelconfig/4.11/scripts/init_script
+++ b/kernelconfig/4.11/scripts/init_script
@@ -20,6 +20,6 @@ mount -t tmpfs shm /dev/shm
 
 # Run gcs in the background
 cd /bin
-./gcs  -loglevel=verbose -logfile=/tmp/gcs.log &
+./gcs  -loglevel=debug -logfile=/tmp/gcs.log &
 cd -
 sh

--- a/service/gcs/main.go
+++ b/service/gcs/main.go
@@ -16,14 +16,14 @@ import (
 )
 
 func main() {
-	logLevel := flag.String("loglevel", "warning", "Logging Level: debug, info, warning, error.")
-	logFile := flag.String("logFile", "", "Logging Target: An optional file name/path. Omit for console output.")
+	logLevel := flag.String("loglevel", "debug", "Logging Level: debug, info, warning, error, fatal, panic.")
+	logFile := flag.String("logfile", "", "Logging Target: An optional file name/path. Omit for console output.")
 
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "\nUsage of %s:\n", os.Args[0])
 		flag.PrintDefaults()
 		fmt.Fprintf(os.Stderr, "Examples:\n")
-		fmt.Fprintf(os.Stderr, "    %s -loglevel=debug -logfile=gcs.log (default)\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "    %s -loglevel=debug -logfile=/tmp/gcs.log\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "    %s -loglevel=info -logfile=stdout\n", os.Args[0])
 	}
 
@@ -31,7 +31,7 @@ func main() {
 
 	// Use a file instead of stdout
 	if *logFile != "" {
-		logFileHandle, err := os.OpenFile(*logFile, os.O_CREATE|os.O_WRONLY, 0600)
+		logFileHandle, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			logrus.Fatalf("failed to create log file %s", *logFile)
 		}

--- a/service/gcsutils/gcstools/commoncli/common.go
+++ b/service/gcsutils/gcstools/commoncli/common.go
@@ -20,7 +20,7 @@ func SetFlagsForTar2VHDLib() []*string {
 	filesystem := flag.String("fs", "ext4", "Filesystem format: ext4")
 	whiteout := flag.String("whiteout", "overlay", "Whiteout format: aufs, overlay")
 	vhdFormat := flag.String("vhd", "fixed", "VHD format: fixed")
-	tempDirectory := flag.String("tmpdir", "/mnt/gcs/LinuxServiceVM/scratch", "Temp directory for intermediate files.")
+	tempDirectory := flag.String("tmpdir", "/tmp/gcs/LinuxServiceVM/scratch", "Temp directory for intermediate files.")
 	return []*string{filesystem, whiteout, vhdFormat, tempDirectory}
 }
 
@@ -82,7 +82,7 @@ func SetupLogging(args ...*string) error {
 
 	logrus.SetLevel(logrus.InfoLevel)
 
-	outputTarget, err := os.OpenFile(*args[0], os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	outputTarget, err := os.OpenFile(*args[0], os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION

With this bug, the following recommend logging option will fail because "verbose" is not a valid option for logrus logging.

Also updated is the recommended gcs command line in 
scripts\init_script
changed from 
./gcs  -loglevel=verbose -logfile=/tmp/gcs.log & 

to

./gcs  -loglevel=debug -logfile=/tmp/gcs.log & 

