### PR TITLE
Implement mapped directories

### DIFF
--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -72,6 +72,7 @@ type containerCacheEntry struct {
 	Processes          []int
 	ExitHooks          []func(oslayer.ProcessExitState)
 	MappedVirtualDisks map[uint8]prot.MappedVirtualDisk
+	MappedDirectories  map[uint32]prot.MappedDirectory
 	NetworkAdapters    []prot.NetworkAdapter
 	container          runtime.Container
 }
@@ -80,6 +81,7 @@ func newContainerCacheEntry(id string) *containerCacheEntry {
 	return &containerCacheEntry{
 		ID:                 id,
 		MappedVirtualDisks: make(map[uint8]prot.MappedVirtualDisk),
+		MappedDirectories:  make(map[uint32]prot.MappedDirectory),
 	}
 }
 func (e *containerCacheEntry) AddExitHook(hook func(oslayer.ProcessExitState)) {
@@ -103,6 +105,20 @@ func (e *containerCacheEntry) RemoveMappedVirtualDisk(disk prot.MappedVirtualDis
 		return errors.Errorf("a mapped virtual disk with lun %d is not attached to container %s", disk.Lun, e.ID)
 	}
 	delete(e.MappedVirtualDisks, disk.Lun)
+	return nil
+}
+func (e *containerCacheEntry) AddMappedDirectory(dir prot.MappedDirectory) error {
+	if _, ok := e.MappedDirectories[dir.Port]; ok {
+		return errors.Errorf("a mapped directory with port %d is already attached to container %s", dir.Port, e.ID)
+	}
+	e.MappedDirectories[dir.Port] = dir
+	return nil
+}
+func (e *containerCacheEntry) RemoveMappedDirectory(dir prot.MappedDirectory) error {
+	if _, ok := e.MappedDirectories[dir.Port]; !ok {
+		return errors.Errorf("a mapped directory with port %d is not attached to container %s", dir.Port, e.ID)
+	}
+	delete(e.MappedDirectories, dir.Port)
 	return nil
 }
 
@@ -142,6 +158,10 @@ func (c *gcsCore) CreateContainer(id string, settings prot.VMHostedContainerSett
 	// Set up mapped virtual disks.
 	if err := c.setupMappedVirtualDisks(id, settings.MappedVirtualDisks, containerEntry); err != nil {
 		return errors.Wrapf(err, "failed to set up mapped virtual disks during create for container %s", id)
+	}
+	// Set up mapped directories.
+	if err := c.setupMappedDirectories(id, settings.MappedDirectories, containerEntry); err != nil {
+		return errors.Wrapf(err, "failed to set up mapped directories during create for container %s", id)
 	}
 
 	// Set up layers.
@@ -472,31 +492,39 @@ func (c *gcsCore) ModifySettings(id string, request prot.ResourceModificationReq
 		return errors.WithStack(gcserr.NewContainerDoesNotExistError(id))
 	}
 
+	settings, ok := request.Settings.(prot.ResourceModificationSettings)
+	if !ok {
+		return errors.New("the request's settings are not of type ResourceModificationSettings")
+	}
 	switch request.RequestType {
 	case prot.RtAdd:
-		if request.ResourceType != prot.PtMappedVirtualDisk {
-			return errors.Errorf("only the resource type \"%s\" is currently supported for request type \"%s\"", prot.PtMappedVirtualDisk, request.RequestType)
-		}
-		settings, ok := request.Settings.(prot.ResourceModificationSettings)
-		if !ok {
-			return errors.New("the request's settings are not of type ResourceModificationSettings")
-		}
-		if err := c.setupMappedVirtualDisks(id, []prot.MappedVirtualDisk{*settings.MappedVirtualDisk}, containerEntry); err != nil {
-			return errors.Wrapf(err, "failed to hot add mapped virtual disk for container %s", id)
+		switch request.ResourceType {
+		case prot.PtMappedVirtualDisk:
+			if err := c.setupMappedVirtualDisks(id, []prot.MappedVirtualDisk{*settings.MappedVirtualDisk}, containerEntry); err != nil {
+				return errors.Wrapf(err, "failed to hot add mapped virtual disk for container %s", id)
+			}
+		case prot.PtMappedDirectory:
+			if err := c.setupMappedDirectories(id, []prot.MappedDirectory{*settings.MappedDirectory}, containerEntry); err != nil {
+				return errors.Wrapf(err, "failed to hot add mapped directory for container %s", id)
+			}
+		default:
+			return errors.Errorf("the resource type \"%s\" is not supported for request type \"%s\"", request.ResourceType, request.RequestType)
 		}
 	case prot.RtRemove:
-		if request.ResourceType != prot.PtMappedVirtualDisk {
-			return errors.Errorf("only the resource type \"%s\" is currently supported for request type \"%s\"", prot.PtMappedVirtualDisk, request.RequestType)
-		}
-		settings, ok := request.Settings.(prot.ResourceModificationSettings)
-		if !ok {
-			return errors.New("the request's settings are not of type ResourceModificationSettings")
-		}
-		if err := c.removeMappedVirtualDisks(id, []prot.MappedVirtualDisk{*settings.MappedVirtualDisk}, containerEntry); err != nil {
-			return errors.Wrapf(err, "failed to hot remove mapped virtual disk for container %s", id)
+		switch request.ResourceType {
+		case prot.PtMappedVirtualDisk:
+			if err := c.removeMappedVirtualDisks(id, []prot.MappedVirtualDisk{*settings.MappedVirtualDisk}, containerEntry); err != nil {
+				return errors.Wrapf(err, "failed to hot remove mapped virtual disk for container %s", id)
+			}
+		case prot.PtMappedDirectory:
+			if err := c.removeMappedDirectories(id, []prot.MappedDirectory{*settings.MappedDirectory}, containerEntry); err != nil {
+				return errors.Wrapf(err, "failed to hot remove mapped directory for container %s", id)
+			}
+		default:
+			return errors.Errorf("the resource type \"%s\" is not supported for request type \"%s\"", request.ResourceType, request.RequestType)
 		}
 	default:
-		return errors.Errorf("the request type \"%s\" is not yet supported", request.RequestType)
+		return errors.Errorf("the request type \"%s\" is not supported", request.RequestType)
 	}
 
 	return nil
@@ -579,6 +607,22 @@ func (c *gcsCore) setupMappedVirtualDisks(id string, disks []prot.MappedVirtualD
 	return nil
 }
 
+// setupMappedDirectories is a helper function which calls into the functions
+// in storage.go to set up a set of mapped directories for a given container.
+// It then adds them to the container's cache entry.
+// This function expects containerCacheMutex to be locked on entry.
+func (c *gcsCore) setupMappedDirectories(id string, dirs []prot.MappedDirectory, containerEntry *containerCacheEntry) error {
+	if err := c.mountMappedDirectories(dirs); err != nil {
+		return errors.Wrapf(err, "failed to mount mapped directories for container %s", id)
+	}
+	for _, dir := range dirs {
+		if err := containerEntry.AddMappedDirectory(dir); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // removeMappedVirtualDisks is a helper function which calls into the functions
 // in storage.go to unmount a set of mapped virtual disks for a given
 // container. It then removes them from the container's cache entry.
@@ -589,6 +633,22 @@ func (c *gcsCore) removeMappedVirtualDisks(id string, disks []prot.MappedVirtual
 	}
 	for _, disk := range disks {
 		if err := containerEntry.RemoveMappedVirtualDisk(disk); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeMappedDirectories is a helper function which calls into the functions
+// in storage.go to unmount a set of mapped directories for a given container.
+// It then removes them from the container's cache entry.
+// This function expects containerCacheMutex to be locked on entry.
+func (c *gcsCore) removeMappedDirectories(id string, dirs []prot.MappedDirectory, containerEntry *containerCacheEntry) error {
+	if err := c.unmountMappedDirectories(dirs); err != nil {
+		return errors.Wrapf(err, "failed to mount mapped directories for container %s", id)
+	}
+	for _, dir := range dirs {
+		if err := containerEntry.RemoveMappedDirectory(dir); err != nil {
 			return err
 		}
 	}

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -947,8 +947,8 @@ var _ = Describe("GCS", func() {
 							Expect(err).NotTo(HaveOccurred())
 							err = coreint.ModifySettings(containerID, diskModificationRequestRemove)
 						})
-						It("should produce an error", func() {
-							Expect(err).To(HaveOccurred())
+						It("should not produce an error", func() {
+							Expect(err).NotTo(HaveOccurred())
 						})
 					})
 					Context("the disk has been added", func() {
@@ -1012,8 +1012,8 @@ var _ = Describe("GCS", func() {
 							Expect(err).NotTo(HaveOccurred())
 							err = coreint.ModifySettings(containerID, dirModificationRequestRemove)
 						})
-						It("should produce an error", func() {
-							Expect(err).To(HaveOccurred())
+						It("should not produce an error", func() {
+							Expect(err).NotTo(HaveOccurred())
 						})
 					})
 					Context("the directory has been added", func() {

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -54,8 +54,8 @@ const (
 )
 
 // GetResponseIdentifier returns the response version of the given request
-// identifier. So, for example, an input of ComputeSystemCreate_v1 would result
-// in an output of ComputeSystemResponseCreate_v1.
+// identifier. So, for example, an input of ComputeSystemCreateV1 would result
+// in an output of ComputeSystemResponseCreateV1.
 func GetResponseIdentifier(identifier MessageIdentifier) MessageIdentifier {
 	return MessageIdentifier(MtResponse | (uint32(identifier) & ^uint32(messageTypeMask)))
 }
@@ -274,6 +274,7 @@ const (
 // ResourceType is checked and only the relevant fields are filled in.
 type ResourceModificationSettings struct {
 	*MappedVirtualDisk
+	*MappedDirectory
 }
 
 // ResourceModificationRequestResponse details a container resource which
@@ -320,6 +321,12 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 		settings.MappedVirtualDisk = &MappedVirtualDisk{}
 		if err := commonutils.UnmarshalJSONWithHresult(rawSettings, settings.MappedVirtualDisk); err != nil {
 			return nil, errors.Wrap(err, "failed to unmarshal settings as MappedVirtualDisk")
+		}
+		request.Request.Settings = settings
+	case PtMappedDirectory:
+		settings.MappedDirectory = &MappedDirectory{}
+		if err := json.Unmarshal(rawSettings, settings.MappedDirectory); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal settings as MappedDirectory")
 		}
 		request.Request.Settings = settings
 	default:
@@ -414,6 +421,15 @@ type MappedVirtualDisk struct {
 	ReadOnly          bool  `json:",omitempty"`
 }
 
+// MappedDirectory represents a directory on the host which is mapped to a
+// directory on the guest through a technology such as Plan9.
+type MappedDirectory struct {
+	ContainerPath     string
+	CreateInUtilityVM bool   `json:",omitempty"`
+	ReadOnly          bool   `json:",omitempty"`
+	Port              uint32 `json:",omitempty"`
+}
+
 // VMHostedContainerSettings is the set of settings used to specify the initial
 // configuration of a container.
 type VMHostedContainerSettings struct {
@@ -422,6 +438,7 @@ type VMHostedContainerSettings struct {
 	// of the sandbox device.
 	SandboxDataPath    string
 	MappedVirtualDisks []MappedVirtualDisk
+	MappedDirectories  []MappedDirectory
 	NetworkAdapters    []NetworkAdapter `json:",omitempty"`
 }
 


### PR DESCRIPTION
These directories are implemented using the Plan9 filesystem. Given a
mount location and a port, the GCS can mount a directory as a Plan9
share to the host.