### PR TITLE
Various fixes to the networking setup

### DIFF
--- a/service/Makefile
+++ b/service/Makefile
@@ -11,7 +11,8 @@ GCS_TOOLS=\
 	tar2vhd \
 	vhd2tar \
 	createSandbox \
-	exportSandbox
+	exportSandbox \
+	netnscfg
 
 GO_FLAGS=-pkgdir "$(WORKDIR)/pkg"
 

--- a/service/gcs/core/gcs/networking.go
+++ b/service/gcs/core/gcs/networking.go
@@ -1,18 +1,94 @@
 package gcs
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 
-	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
+	"github.com/Sirupsen/logrus"
 	"github.com/pkg/errors"
 )
+
+// configureAdapterInNamespace moves a given adapter into a network
+// namespace and configures it there.
+func (c *gcsCore) configureAdapterInNamespace(container runtime.Container, adapter prot.NetworkAdapter) error {
+	id := adapter.AdapterInstanceID
+	interfaceName, err := c.instanceIDToName(id)
+	if err != nil {
+		return err
+	}
+	nspid := container.Pid()
+	cfg, err := json.Marshal(adapter)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal adapter struct to JSON for adapter %s", id)
+	}
+
+	out, err := c.OS.Command("netnscfg",
+		"-if", interfaceName,
+		"-nspid", fmt.Sprintf("%d", nspid),
+		"-cfg", string(cfg)).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to configure network adapter %s: %s", adapter.AdapterInstanceID, out)
+	}
+	logrus.Debugf("netnscfg output:\n%s", out)
+
+	// Handle resolve.conf
+	// There is no need to create <baseFilesPath>/etc here as it
+	// is created in CreateContainer().
+	resolvPath := filepath.Join(baseFilesPath, "etc/resolv.conf")
+
+	if adapter.NatEnabled {
+		// Set the DNS configuration.
+		if err := c.generateResolvConfFile(resolvPath, adapter); err != nil {
+			return errors.Wrapf(err, "failed to generate resolv.conf file for adapter %s", adapter.AdapterInstanceID)
+		}
+	} else {
+		exists, err := c.OS.PathExists(resolvPath)
+		if err != nil {
+			return errors.Wrapf(err, "failed to check if resolv.conf path already exists for adapter %s", adapter.AdapterInstanceID)
+		}
+		if !exists {
+			if err := c.OS.Link("/etc/resolv.conf", resolvPath); err != nil {
+				return errors.Wrapf(err, "failed to link resolv.conf file for adapter %s", adapter.AdapterInstanceID)
+			}
+		}
+
+	}
+	return nil
+}
+
+// generateResolvConfFile generate a resolve.conf file in $baseFilesPath/etc
+// for the given adapter.
+// TODO: This method of managing DNS will potentially be replaced with another
+// method in the future.
+func (c *gcsCore) generateResolvConfFile(resolvPath string, adapter prot.NetworkAdapter) error {
+	fileContents := ""
+	nameservers := strings.Split(adapter.HostDNSServerList, " ")
+	for i, server := range nameservers {
+		// Limit number of nameservers to 3.
+		if i >= 3 {
+			break
+		}
+		fileContents += fmt.Sprintf("nameserver %s\n", server)
+	}
+	fileContents += fmt.Sprintf("search %s\n", adapter.HostDNSSuffix)
+
+	file, err := c.OS.OpenFile(resolvPath, os.O_CREATE|os.O_WRONLY, 0700)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create resolv.conf file for adapter %s", adapter.AdapterInstanceID)
+	}
+	defer file.Close()
+	if _, err := io.WriteString(file, fileContents); err != nil {
+		return errors.Wrapf(err, "failed to write to resolv.conf file for adapter %s", adapter.AdapterInstanceID)
+	}
+	logrus.Debugf("wrote %s:\n%s", resolvPath, fileContents)
+	return nil
+}
 
 // instanceIDToName converts from the given instance ID (a GUID generated on
 // the Windows host) to its corresponding interface name (e.g. "eth0").
@@ -28,218 +104,4 @@ func (c *gcsCore) instanceIDToName(id string) (string, error) {
 		return "", errors.Errorf("multiple interface names found for adapter %s", id)
 	}
 	return deviceDirs[0].Name(), nil
-}
-
-// getLinkForAdapter returns the oslayer.Link corresponding to the given
-// network adapter.
-func (c *gcsCore) getLinkForAdapter(adapter prot.NetworkAdapter) (oslayer.Link, error) {
-	id := adapter.AdapterInstanceID
-	interfaceName, err := c.instanceIDToName(id)
-	if err != nil {
-		return nil, err
-	}
-	link, err := c.OS.GetLinkByName(interfaceName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get network interface for adapter %s", id)
-	}
-	return link, nil
-}
-
-// configureNetworkAdapter configures the given network adapter to be used by
-// the container.
-func (c *gcsCore) configureNetworkAdapter(adapter prot.NetworkAdapter) error {
-	link, err := c.getLinkForAdapter(adapter)
-	if err != nil {
-		return err
-	}
-	if err := link.SetUp(); err != nil {
-		return errors.Wrapf(err, "failed to set link up for adapter %s", adapter.AdapterInstanceID)
-	}
-
-	// Create the directory that will contain the resolv.conf file.
-	if err := c.OS.MkdirAll(filepath.Join(baseFilesPath, "etc"), 0700); err != nil {
-		return errors.Wrapf(err, "failed to create resolv.conf directory for adapter %s", adapter.AdapterInstanceID)
-	}
-
-	if adapter.NatEnabled {
-		if err := c.configureNAT(adapter); err != nil {
-			return errors.Wrapf(err, "failed to configure NAT on adapter %s", adapter.AdapterInstanceID)
-		}
-	} else {
-		if err := c.configureWithDHCP(adapter); err != nil {
-			return errors.Wrapf(err, "failed to configure DHCP on adapter %s", adapter.AdapterInstanceID)
-		}
-	}
-	return nil
-}
-
-// configureNAT configures the given network adapter using the information
-// specified in the NetworkAdapter struct.
-func (c *gcsCore) configureNAT(adapter prot.NetworkAdapter) error {
-	link, err := c.getLinkForAdapter(adapter)
-	if err != nil {
-		return err
-	}
-
-	// Set the route metric.
-	metric := 1
-	if adapter.EnableLowMetric {
-		metric = 500
-	}
-
-	// Set the IP address.
-	addr, err := c.OS.ParseAddr(fmt.Sprintf("%s/%d", adapter.AllocatedIPAddress, adapter.HostIPPrefixLength))
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse allocated address for adapter %s", adapter.AdapterInstanceID)
-	}
-	if err := link.AddAddr(addr); err != nil {
-		return errors.Wrapf(err, "failed to add address %s to adapter %s", addr.String(), adapter.AdapterInstanceID)
-	}
-
-	// Set the gateway route.
-	if adapter.HostIPAddress != "" {
-		addrString := adapter.HostIPAddress
-		// If this isn't a valid CIDR address.
-		if !strings.Contains(addrString, "/") {
-			addrString += "/32"
-		}
-		addr, err := c.OS.ParseAddr(addrString)
-		if err != nil {
-			return errors.Wrapf(err, "invalid host IP address %s for adapter %s", adapter.HostIPAddress, adapter.AdapterInstanceID)
-		}
-		if err := c.OS.AddGatewayRoute(addr, link, metric); err != nil {
-			return errors.Wrapf(err, "failed to set NAT route %s for adapter %s", adapter.HostIPAddress, adapter.AdapterInstanceID)
-		}
-	}
-
-	// Set the DNS configuration.
-	if err := c.generateResolvConfFile(adapter); err != nil {
-		return errors.Wrapf(err, "failed to generate resolv.conf file for adapter %s", adapter.AdapterInstanceID)
-	}
-
-	return nil
-}
-
-// configureWithDHCP configures the given network adapter using DHCP.
-func (c *gcsCore) configureWithDHCP(adapter prot.NetworkAdapter) error {
-	// TODO: change this to dhclient -r <interfacename>
-	id := adapter.AdapterInstanceID
-	interfaceName, err := c.instanceIDToName(id)
-	if err != nil {
-		return err
-	}
-	out, err := c.OS.Command("udhcpc", "-q", "-i", interfaceName, "-s", "/sbin/udhcpc_config.script").CombinedOutput()
-	if err != nil {
-		return errors.Wrapf(err, "failed call to udhcpc for adapter %s: %s", adapter.AdapterInstanceID, out)
-	}
-	resolvPath := filepath.Join(baseFilesPath, "etc/resolv.conf")
-	exists, err := c.OS.PathExists(resolvPath)
-	if err != nil {
-		return errors.Wrapf(err, "failed to check if resolv.conf path already exists for adapter %s", adapter.AdapterInstanceID)
-	}
-	if !exists {
-		if err := c.OS.Link("/etc/resolv.conf", resolvPath); err != nil {
-			return errors.Wrapf(err, "failed to link resolv.conf file for adapter %s", adapter.AdapterInstanceID)
-		}
-	}
-	return nil
-}
-
-// generateResolvConfFile generate a resolve.conf file in $baseFilesPath/etc
-// for the given adapter.
-// TODO: This method of managing DNS will potentially be replaced with another
-// method in the future.
-func (c *gcsCore) generateResolvConfFile(adapter prot.NetworkAdapter) error {
-	fileContents := ""
-	nameservers := strings.Split(adapter.HostDNSServerList, " ")
-	for i, server := range nameservers {
-		// Limit number of nameservers to 3.
-		if i >= 3 {
-			break
-		}
-		fileContents += fmt.Sprintf("nameserver %s\n", server)
-	}
-	fileContents += fmt.Sprintf("search %s\n", adapter.HostDNSSuffix)
-
-	file, err := c.OS.OpenFile(filepath.Join(baseFilesPath, "etc", "resolv.conf"), os.O_CREATE|os.O_WRONLY, 0700)
-	if err != nil {
-		return errors.Wrapf(err, "failed to create resolv.conf file for adapter %s", adapter.AdapterInstanceID)
-	}
-	defer file.Close()
-	if _, err := io.WriteString(file, fileContents); err != nil {
-		return errors.Wrapf(err, "failed to write to resolv.conf file for adapter %s", adapter.AdapterInstanceID)
-	}
-	return nil
-}
-
-// moveAdapterIntoNamespace moves the given network adapter into the namespace
-// of the container with the given ID.
-func (c *gcsCore) moveAdapterIntoNamespace(container runtime.Container, adapter prot.NetworkAdapter) error {
-	// Get the root namespace, which should be the GCS's current namespace.
-	rootNamespace, err := c.OS.GetCurrentNamespace()
-	if err != nil {
-		return errors.Wrap(err, "failed to get the root namespace")
-	}
-	defer rootNamespace.Close()
-
-	// Get namespace information for the container process.
-	containerNamespace, err := c.OS.GetNamespaceFromPid(container.Pid())
-	if err != nil {
-		return errors.Wrapf(err, "failed to get the namespace of process %d", container.Pid())
-	}
-	defer containerNamespace.Close()
-
-	// Move the interface into the container namespace.
-	link, err := c.getLinkForAdapter(adapter)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get the link for adapter %s in preparation for moving it into the container namespace", adapter.AdapterInstanceID)
-	}
-	addrs, err := link.Addrs(syscall.AF_INET)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get the addrs for adapter %s", adapter.AdapterInstanceID)
-	}
-	gateways, err := link.GatewayRoutes(syscall.AF_INET)
-	if err != nil {
-		return errors.Wrapf(err, "failed to get the gateway routes for adapter %s", adapter.AdapterInstanceID)
-	}
-	if err := link.SetDown(); err != nil {
-		return errors.Wrapf(err, "failed to set link down for adapter %s", adapter.AdapterInstanceID)
-	}
-	if err := link.SetNamespace(containerNamespace); err != nil {
-		return errors.Wrapf(err, "failed to set the link to new namespace for adapter %s", adapter.AdapterInstanceID)
-	}
-	if err := c.OS.SetCurrentNamespace(containerNamespace); err != nil {
-		return errors.Wrapf(err, "failed to set the namespace to the container namespace for container %s", container.ID())
-	}
-
-	// Configure the interface with its original configuration.
-	for _, addr := range addrs {
-		// TODO: addr should never be nil
-		if addr != nil {
-			if err := link.AddAddr(addr); err != nil {
-				return errors.Wrapf(err, "failed to set the IP address of the network interface for adapter %s", adapter.AdapterInstanceID)
-			}
-		}
-	}
-	if err := link.SetUp(); err != nil {
-		return errors.Wrapf(err, "failed to set link up for adapter %s", adapter.AdapterInstanceID)
-	}
-	for _, route := range gateways {
-		// TODO: gatewayRoute should never be nil
-		if route != nil {
-			link, err := c.OS.GetLinkByIndex(route.LinkIndex())
-			if err != nil {
-				return errors.Wrapf(err, "failed to get the link with index %d for adapter %s", route.LinkIndex(), adapter.AdapterInstanceID)
-			}
-			if err := c.OS.AddGatewayRoute(route.Gw(), link, route.Metric()); err != nil {
-				return errors.Wrapf(err, "failed to add the gateway route for adapter %s", adapter.AdapterInstanceID)
-			}
-		}
-	}
-
-	// Change back to the root namespace.
-	if err := c.OS.SetCurrentNamespace(rootNamespace); err != nil {
-		return errors.Wrap(err, "failed to set the namespace to the root namespace")
-	}
-	return nil
 }

--- a/service/gcs/core/gcs/networking.go
+++ b/service/gcs/core/gcs/networking.go
@@ -68,7 +68,7 @@ func (c *gcsCore) configureAdapterInNamespace(container runtime.Container, adapt
 // method in the future.
 func (c *gcsCore) generateResolvConfFile(resolvPath string, adapter prot.NetworkAdapter) error {
 	fileContents := ""
-	nameservers := strings.Split(adapter.HostDNSServerList, " ")
+	nameservers := strings.Split(adapter.HostDNSServerList, ",")
 	for i, server := range nameservers {
 		// Limit number of nameservers to 3.
 		if i >= 3 {
@@ -78,7 +78,7 @@ func (c *gcsCore) generateResolvConfFile(resolvPath string, adapter prot.Network
 	}
 	fileContents += fmt.Sprintf("search %s\n", adapter.HostDNSSuffix)
 
-	file, err := c.OS.OpenFile(resolvPath, os.O_CREATE|os.O_WRONLY, 0700)
+	file, err := c.OS.OpenFile(resolvPath, os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return errors.Wrapf(err, "failed to create resolv.conf file for adapter %s", adapter.AdapterInstanceID)
 	}

--- a/service/gcs/oslayer/mockos/mockos.go
+++ b/service/gcs/oslayer/mockos/mockos.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -153,114 +152,12 @@ func (i *mockFileInfo) Sys() interface{} {
 	return i.sys
 }
 
-type mockNetworkInterface struct {
-	link    oslayer.Link
-	addr    oslayer.Addr
-	gateway oslayer.Route
-}
-
-func (i *mockNetworkInterface) Link() oslayer.Link {
-	return i.link
-}
-func (i *mockNetworkInterface) Addr() oslayer.Addr {
-	return i.addr
-}
-func (i *mockNetworkInterface) Gateway() oslayer.Route {
-	return i.gateway
-}
-
-type mockLink struct {
-	name  string
-	index int
-	addrs []oslayer.Addr
-}
-
-func newLink(name string, index int, addrs []oslayer.Addr) *mockLink {
-	return &mockLink{
-		name:  name,
-		index: index,
-		addrs: addrs,
-	}
-}
-func (l *mockLink) Name() string {
-	return l.name
-}
-func (l *mockLink) Index() int {
-	return l.index
-}
-func (l *mockLink) SetUp() error {
-	return nil
-}
-func (l *mockLink) SetDown() error {
-	return nil
-}
-func (l *mockLink) SetNamespace(namespace oslayer.Namespace) error {
-	return nil
-}
-func (l *mockLink) Addrs(family int) ([]oslayer.Addr, error) {
-	return l.addrs, nil
-}
-func (l *mockLink) AddAddr(addr oslayer.Addr) error {
-	l.addrs = append(l.addrs, addr)
-	return nil
-}
-func (l *mockLink) GatewayRoutes(family int) ([]oslayer.Route, error) {
-	return []oslayer.Route{
-		newRoute(newAddr()),
-	}, nil
-}
-
-type mockAddr struct{}
-
-func newAddr() *mockAddr {
-	return &mockAddr{}
-}
-func (a *mockAddr) IP() net.IP {
-	return net.ParseIP("0.0.0.0")
-}
-func (a *mockAddr) String() string {
-	return ""
-}
-
-type mockRoute struct {
-	gw     oslayer.Addr
-	metric int
-}
-
-func newRoute(gw oslayer.Addr) *mockRoute {
-	return &mockRoute{gw: gw}
-}
-func (r *mockRoute) Gw() oslayer.Addr {
-	return r.gw
-}
-func (r *mockRoute) Metric() int {
-	return r.metric
-}
-func (r *mockRoute) SetMetric(metric int) {
-	r.metric = metric
-}
-func (r *mockRoute) LinkIndex() int {
-	return 0
-}
-
-type mockNamespace struct{}
-
-func newNamespace() *mockNamespace {
-	return &mockNamespace{}
-}
-func (n *mockNamespace) Close() error {
-	return nil
-}
-
 type mockOS struct {
-	CurrentNamespace oslayer.Namespace
 }
 
 // NewOS returns a *mockOS, which mocks out operating system functionality.
 func NewOS() *mockOS {
-	return &mockOS{
-		CurrentNamespace: newNamespace(),
-	}
+	return &mockOS{}
 }
 
 // Filesystem
@@ -299,36 +196,6 @@ func (o *mockOS) PathIsMounted(name string) (bool, error) {
 }
 func (o *mockOS) Link(oldname, newname string) error {
 	return nil
-}
-
-// Networking
-func (o *mockOS) GetLinkByName(name string) (oslayer.Link, error) {
-	return newLink(name, 0, []oslayer.Addr{newAddr()}), nil
-}
-func (o *mockOS) GetLinkByIndex(index int) (oslayer.Link, error) {
-	return newLink("", index, []oslayer.Addr{newAddr()}), nil
-}
-func (o *mockOS) GetCurrentNamespace() (oslayer.Namespace, error) {
-	return o.CurrentNamespace, nil
-}
-func (o *mockOS) SetCurrentNamespace(namespace oslayer.Namespace) error {
-	o.CurrentNamespace = namespace
-	return nil
-}
-func (o *mockOS) GetNamespaceFromPid(pid int) (oslayer.Namespace, error) {
-	return newNamespace(), nil
-}
-func (o *mockOS) NewRoute(scope uint8, linkIndex int, gateway oslayer.Addr) oslayer.Route {
-	return newRoute(gateway)
-}
-func (o *mockOS) AddRoute(route oslayer.Route) error {
-	return nil
-}
-func (o *mockOS) AddGatewayRoute(gw oslayer.Addr, link oslayer.Link, metric int) error {
-	return nil
-}
-func (o *mockOS) ParseAddr(s string) (oslayer.Addr, error) {
-	return newAddr(), nil
 }
 
 // Processes

--- a/service/gcs/oslayer/oslayer.go
+++ b/service/gcs/oslayer/oslayer.go
@@ -1,10 +1,9 @@
 // Package oslayer defines the interface between the GCS and operating system
-// functionality such as filesystem access and networking.
+// functionality such as filesystem access.
 package oslayer
 
 import (
 	"io"
-	"net"
 	"os"
 	"syscall"
 )
@@ -56,37 +55,6 @@ type Cmd interface {
 	CombinedOutput() ([]byte, error)
 }
 
-// Link is an interface describing a network link.
-type Link interface {
-	Name() string
-	Index() int
-	SetUp() error
-	SetDown() error
-	SetNamespace(namespace Namespace) error
-	Addrs(family int) ([]Addr, error)
-	AddAddr(addr Addr) error
-	GatewayRoutes(family int) ([]Route, error)
-}
-
-// Addr is an interface describing a network address.
-type Addr interface {
-	IP() net.IP
-	String() string
-}
-
-// Route is an interface describing a network route.
-type Route interface {
-	Gw() Addr
-	Metric() int
-	SetMetric(metric int)
-	LinkIndex() int
-}
-
-// Namespace is an interface describing a network namespace.
-type Namespace interface {
-	io.Closer
-}
-
 // OS is the interface describing operations that can be performed on and by
 // the operating system, such as filesystem access and networking.
 type OS interface {
@@ -102,17 +70,6 @@ type OS interface {
 	PathExists(name string) (bool, error)
 	PathIsMounted(name string) (bool, error)
 	Link(oldname, newname string) error
-
-	// Networking
-	GetLinkByName(name string) (Link, error)
-	GetLinkByIndex(index int) (Link, error)
-	GetCurrentNamespace() (Namespace, error)
-	SetCurrentNamespace(namespace Namespace) error
-	GetNamespaceFromPid(pid int) (Namespace, error)
-	NewRoute(scope uint8, linkIndex int, gateway Addr) Route
-	AddRoute(route Route) error
-	AddGatewayRoute(gw Addr, link Link, metric int) error
-	ParseAddr(s string) (Addr, error)
 
 	// Processes
 	Kill(pid int, sig syscall.Signal) error

--- a/service/gcs/oslayer/realos/realos.go
+++ b/service/gcs/oslayer/realos/realos.go
@@ -5,16 +5,12 @@ package realos
 import (
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
 	"os/exec"
-	"strconv"
 	"syscall"
 
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/pkg/errors"
-	"github.com/vishvananda/netlink"
-	"github.com/vishvananda/netns"
 )
 
 // realProcessExitState represents an oslayer.ProcessExitState which uses an
@@ -129,115 +125,6 @@ func (c *realCmd) CombinedOutput() ([]byte, error) {
 	return out, nil
 }
 
-type realLink struct {
-	link netlink.Link
-}
-
-func (l *realLink) Name() string {
-	return l.link.Attrs().Name
-}
-func (l *realLink) Index() int {
-	return l.link.Attrs().Index
-}
-func (l *realLink) SetUp() error {
-	if err := netlink.LinkSetUp(l.link); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-func (l *realLink) SetDown() error {
-	if err := netlink.LinkSetDown(l.link); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-func (l *realLink) SetNamespace(namespace oslayer.Namespace) error {
-	fd := int(*namespace.(*realNamespace).nsHandle)
-	if err := netlink.LinkSetNsFd(l.link, fd); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-func (l *realLink) Addrs(family int) ([]oslayer.Addr, error) {
-	addrs, err := netlink.AddrList(l.link, family)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	addrsToReturn := make([]oslayer.Addr, len(addrs))
-	for _, addr := range addrs {
-		addrsToReturn = append(addrsToReturn, newAddr(&addr))
-	}
-	return addrsToReturn, nil
-}
-func (l *realLink) AddAddr(addr oslayer.Addr) error {
-	if err := netlink.AddrAdd(l.link, addr.(*realAddr).addr); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-func (l *realLink) GatewayRoutes(family int) ([]oslayer.Route, error) {
-	filter := &netlink.Route{LinkIndex: l.Index(), Dst: nil}
-	routes, err := netlink.RouteListFiltered(family, filter, netlink.RT_FILTER_OIF|netlink.RT_FILTER_DST)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	routesToReturn := make([]oslayer.Route, len(routes))
-	for _, route := range routes {
-		routesToReturn = append(routesToReturn, newRoute(&route))
-	}
-	return routesToReturn, nil
-}
-
-type realAddr struct {
-	addr *netlink.Addr
-}
-
-func newAddr(addr *netlink.Addr) *realAddr {
-	return &realAddr{addr: addr}
-}
-func (a *realAddr) IP() net.IP {
-	return a.addr.IP
-}
-func (a *realAddr) String() string {
-	return a.addr.String()
-}
-
-type realRoute struct {
-	route *netlink.Route
-}
-
-func newRoute(route *netlink.Route) *realRoute {
-	return &realRoute{route: route}
-}
-func (r *realRoute) Gw() oslayer.Addr {
-	ip := r.route.Gw
-	mask := net.IPv4Mask(255, 255, 255, 255)
-	return newAddr(&netlink.Addr{IPNet: &net.IPNet{IP: ip, Mask: mask}})
-}
-func (r *realRoute) Metric() int {
-	return r.route.Priority
-}
-func (r *realRoute) SetMetric(metric int) {
-	r.route.Priority = metric
-}
-func (r *realRoute) LinkIndex() int {
-	return r.route.LinkIndex
-}
-
-type realNamespace struct {
-	nsHandle *netns.NsHandle
-}
-
-func newNamespace(nsHandle *netns.NsHandle) *realNamespace {
-	return &realNamespace{nsHandle: nsHandle}
-}
-func (n *realNamespace) Close() error {
-	if err := n.nsHandle.Close(); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-
 type realOS struct{}
 
 // NewOS returns a *realOS OS interface implementation which calls into actual
@@ -323,67 +210,6 @@ func (o *realOS) Link(oldname, newname string) error {
 		return errors.WithStack(err)
 	}
 	return nil
-}
-
-// Networking
-func (o *realOS) GetLinkByName(name string) (oslayer.Link, error) {
-	link, err := netlink.LinkByName(name)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return &realLink{link: link}, nil
-}
-func (o *realOS) GetLinkByIndex(index int) (oslayer.Link, error) {
-	link, err := netlink.LinkByIndex(index)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return &realLink{link: link}, nil
-}
-func (o *realOS) GetCurrentNamespace() (oslayer.Namespace, error) {
-	nsHandle, err := netns.Get()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return newNamespace(&nsHandle), nil
-}
-func (o *realOS) SetCurrentNamespace(namespace oslayer.Namespace) error {
-	if err := netns.Set(*namespace.(*realNamespace).nsHandle); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-func (o *realOS) GetNamespaceFromPid(pid int) (oslayer.Namespace, error) {
-	nsHandle, err := netns.GetFromPid(pid)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return newNamespace(&nsHandle), nil
-}
-func (o *realOS) NewRoute(scope uint8, linkIndex int, gateway oslayer.Addr) oslayer.Route {
-	netlinkRoute := &netlink.Route{Scope: netlink.Scope(scope), LinkIndex: linkIndex, Gw: gateway.IP()}
-	return newRoute(netlinkRoute)
-}
-func (o *realOS) AddRoute(route oslayer.Route) error {
-	netlinkRoute := route.(*realRoute).route
-	if err := netlink.RouteAdd(netlinkRoute); err != nil {
-		return errors.WithStack(err)
-	}
-	return nil
-}
-func (o *realOS) AddGatewayRoute(gw oslayer.Addr, link oslayer.Link, metric int) error {
-	out, err := exec.Command("route", "add", "default", "gw", gw.IP().String(), "dev", link.Name(), "metric", strconv.Itoa(metric)).CombinedOutput()
-	if err != nil {
-		return errors.Errorf("%s", out)
-	}
-	return nil
-}
-func (o *realOS) ParseAddr(s string) (oslayer.Addr, error) {
-	addr, err := netlink.ParseAddr(s)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	return newAddr(addr), nil
 }
 
 // Processes

--- a/service/gcs/runtime/runc/runc.go
+++ b/service/gcs/runtime/runc/runc.go
@@ -23,7 +23,6 @@ import (
 )
 
 const (
-	runcPath          = "/sbin/runc"
 	containerFilesDir = "/var/run/gcsrunc"
 	initPidFilename   = "initpid"
 )
@@ -98,7 +97,7 @@ func (r *runcRuntime) CreateContainer(id string, bundlePath string, stdioSet *st
 // CreateContainer.
 func (c *container) Start() error {
 	logPath := c.r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "start", c.id)
+	cmd := exec.Command("runc", "--log", logPath, "start", c.id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		c.r.cleanupContainer(c.id)
@@ -120,7 +119,7 @@ func (c *container) ExecProcess(process oci.Process, stdioSet *stdio.ConnectionS
 // Kill sends the specified signal to the container's init process.
 func (c *container) Kill(signal oslayer.Signal) error {
 	logPath := c.r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "kill", c.id, strconv.Itoa(int(signal)))
+	cmd := exec.Command("runc", "--log", logPath, "kill", c.id, strconv.Itoa(int(signal)))
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "runc kill failed with: %s", out)
@@ -132,7 +131,7 @@ func (c *container) Kill(signal oslayer.Signal) error {
 // wrapper or runC itself.
 func (c *container) Delete() error {
 	logPath := c.r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "delete", c.id)
+	cmd := exec.Command("runc", "--log", logPath, "delete", c.id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "runc delete failed with: %s", out)
@@ -155,7 +154,7 @@ func (p *process) Delete() error {
 // Pause suspends all processes running in the container.
 func (c *container) Pause() error {
 	logPath := c.r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "pause", c.id)
+	cmd := exec.Command("runc", "--log", logPath, "pause", c.id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "runc pause failed with: %s", out)
@@ -166,7 +165,7 @@ func (c *container) Pause() error {
 // Resume unsuspends processes running in the container.
 func (c *container) Resume() error {
 	logPath := c.r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "resume", c.id)
+	cmd := exec.Command("runc", "--log", logPath, "resume", c.id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return errors.Wrapf(err, "runc resume failed with: %s", out)
@@ -177,7 +176,7 @@ func (c *container) Resume() error {
 // GetState returns information about the given container.
 func (c *container) GetState() (*runtime.ContainerState, error) {
 	logPath := c.r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "state", c.id)
+	cmd := exec.Command("runc", "--log", logPath, "state", c.id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrapf(err, "runc state failed with: %s", out)
@@ -212,7 +211,7 @@ func (c *container) Exists() (bool, error) {
 // containers, whether they're running or not.
 func (r *runcRuntime) ListContainerStates() ([]runtime.ContainerState, error) {
 	logPath := r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "list", "-f", "json")
+	cmd := exec.Command("runc", "--log", logPath, "list", "-f", "json")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrapf(err, "runc list failed with: %s", out)
@@ -321,7 +320,7 @@ func (c *container) GetAllProcesses() ([]runtime.ContainerProcessState, error) {
 // running.
 func (r *runcRuntime) getRunningPids(id string) ([]int, error) {
 	logPath := r.getLogPath()
-	cmd := exec.Command(runcPath, "--log", logPath, "ps", "-f", "json", id)
+	cmd := exec.Command("runc", "--log", logPath, "ps", "-f", "json", id)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrapf(err, "runc ps failed with: %s", out)
@@ -506,7 +505,7 @@ func (c *container) startProcess(tempProcessDir string, hasTerminal bool, stdioS
 	}
 	args = append(args, c.id)
 
-	cmd := exec.Command(runcPath, args...)
+	cmd := exec.Command("runc", args...)
 	if !hasTerminal {
 		fileSet, err := stdioSet.Files()
 		if err != nil {

--- a/service/gcsutils/gcstools/main.go
+++ b/service/gcsutils/gcstools/main.go
@@ -11,6 +11,7 @@ var commands = map[string]func(){
 	"vhd2tar":       vhd2tarMain,
 	"createSandbox": createSandboxMain,
 	"exportSandbox": exportSandboxMain,
+	"netnscfg":      netnsConfigMain,
 }
 
 func main() {

--- a/service/gcsutils/gcstools/netnsConfig.go
+++ b/service/gcsutils/gcstools/netnsConfig.go
@@ -1,0 +1,157 @@
+package main
+
+// This utility moves a network interface into a network namespace and
+// configures it. The configuration is passed in as a JSON object
+// (marshalled prot.NetworkAdapter).  It is necessary to implement
+// this as a separate utility as in Go one does not have tight control
+// over which OS thread a given Go thread/routing executes but as can
+// only enter a namespace with a specific OS thread.
+//
+// Note, this logs to stdout so that the caller (gcs) can log the
+// output itself.
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/Microsoft/opengcs/service/gcs/prot"
+	log "github.com/Sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netns"
+)
+
+func netnsConfigMain() {
+	if err := netnsConfig(); err != nil {
+		log.Fatal("netnsConfig returned: ", err)
+	}
+	os.Exit(0)
+}
+
+func netnsConfig() error {
+	ifStr := flag.String("if", "", "Interface/Adapter to move/configure")
+	nspid := flag.Int("nspid", -1, "Process ID (to locate netns")
+	cfgStr := flag.String("cfg", "", "Adapter configuration (json)")
+
+	flag.Parse()
+	if *ifStr == "" || *nspid == -1 || *cfgStr == "" {
+		return fmt.Errorf("All three arguments must be specified")
+	}
+
+	var a prot.NetworkAdapter
+	if err := json.Unmarshal([]byte(*cfgStr), &a); err != nil {
+		return err
+	}
+
+	if a.NatEnabled {
+		log.Infof("Configure %s in %d with: %s/%d gw=%s", *ifStr, *nspid, a.AllocatedIPAddress, a.HostIPPrefixLength, a.HostIPAddress)
+	} else {
+		log.Infof("Configure %s in %s with DHCP", *ifStr, *nspid)
+	}
+
+	// Lock the OS Thread so we don't accidentally switch namespaces
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	// Stash current network namespace away and make sure we enter it as we leave
+	origNS, err := netns.Get()
+	if err != nil {
+		return fmt.Errorf("netns.Get() failed: %v", err)
+	}
+	defer origNS.Close()
+
+	// Get a reference to the new network namespace
+	ns, err := netns.GetFromPid(*nspid)
+	if err != nil {
+		return fmt.Errorf("netns.GetFromPid(%d) failed: %v", *nspid, err)
+	}
+	defer ns.Close()
+
+	// Get a reference to the interface and make sure it's down
+	link, err := netlink.LinkByName(*ifStr)
+	if err != nil {
+		return fmt.Errorf("netlink.LinkByName(%s) failed: %v", *ifStr, err)
+	}
+	if err := netlink.LinkSetDown(link); err != nil {
+		return fmt.Errorf("netlink.LinkSetDown(%#v) failed: %v", link, err)
+	}
+
+	// Move the interface to the new network namespace
+	if err := netlink.LinkSetNsPid(link, *nspid); err != nil {
+		return fmt.Errorf("netlink.SetNsPid(%#v, %d) failed: %v", link, *nspid, err)
+	}
+
+	log.Infof("Switching from %v to %v", origNS, ns)
+
+	// Enter the new network namespace
+	if err := netns.Set(ns); err != nil {
+		return fmt.Errorf("netns.Set() failed: %v", err)
+	}
+
+	// Re-Get a reference to the interface (it may be a different ID in the new namespace)
+	link, err = netlink.LinkByName(*ifStr)
+	if err != nil {
+		return fmt.Errorf("netlink.LinkByName(%s) failed: %v", *ifStr, err)
+	}
+
+	// Configure the interface
+	if a.NatEnabled {
+		metric := 1
+		if a.EnableLowMetric {
+			metric = 500
+		}
+
+		// Bring the interface up
+		if err := netlink.LinkSetUp(link); err != nil {
+			return fmt.Errorf("netlink.LinkSetUp(%#v) failed: %v", link, err)
+		}
+		// Set IP address
+		addr := &net.IPNet{
+			IP: net.ParseIP(a.AllocatedIPAddress),
+			// TODO(rn): This assumes/hardcodes IPv4
+			Mask: net.CIDRMask(int(a.HostIPPrefixLength), 32)}
+		ipAddr := &netlink.Addr{IPNet: addr, Label: ""}
+		if err := netlink.AddrAdd(link, ipAddr); err != nil {
+			return fmt.Errorf("netlink.AddrAdd(%#v, %#v) failed: %v", link, ipAddr, err)
+		}
+		// Set gateway
+		if a.HostIPAddress != "" {
+			gw := net.ParseIP(a.HostIPAddress)
+			route := netlink.Route{
+				Scope:     netlink.SCOPE_UNIVERSE,
+				LinkIndex: link.Attrs().Index,
+				Gw:        gw,
+				Priority:  metric, // This is what ip route add does
+			}
+			if err := netlink.RouteAdd(&route); err != nil {
+				return fmt.Errorf("netlink.RouteAdd(%#v) failed: %v", route, err)
+			}
+		}
+	} else {
+		err := exec.Command(
+			"udhcpc",
+			"-q",
+			"-i", *ifStr,
+			"-s", "/sbin/udhcpc_config.script").Run()
+		if err != nil {
+			return fmt.Errorf("udhcpc failed: %v", err)
+		}
+	}
+
+	// Add some debug logging
+	curNS, _ := netns.Get()
+	// Refresh link attributes/state
+	link, _ = netlink.LinkByIndex(link.Attrs().Index)
+	attr := link.Attrs()
+	addrs, _ := netlink.AddrList(link, 0)
+	log.Infof("%v: %s[idx=%d,type=%s] is %v", curNS, attr.Name, attr.Index, link.Type(), attr.OperState)
+	for _, addr := range addrs {
+		log.Infof("  %v", addr)
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Factor out networking setup into a separate tool (netnscfg). This is necessary because in Go one has little control over which kernel thread a go routine runs on and one can only enter the current kernel thread into a network namespace. Using a separate utility fixes this.
- Setup the network interfaces directly with the target namespace. This simplifies the network config and makes it more future proof. Previously, the network interface were configured in the root namespace and then the config was move. Setting up the interfaces directly in the target namespace saves us from having to gather the current network config and then trying to recreate it, which would become quite tedious once VXLAN, different MTU sizes etc are supported.
- Handle the case where the network interface may have a different ID inside the namespace.
- Fix resolv.conf. The format and permission were wrong.
- Remove networking and namespace code as it is no longer needed.
- Improve logging of the network setup throughout

I've tested this with LinuxKit and both `nat` and `dhcp` mode of networking config and verified network connectivity from within the container.

resolves #56