### PR TITLE
moved temp mount directories away from read-only directory

### DIFF
--- a/service/gcsutils/libtar2vhd/tar2vhd.go
+++ b/service/gcsutils/libtar2vhd/tar2vhd.go
@@ -80,7 +80,7 @@ func VHD2Tar(in io.Reader, out io.Writer, options *Options) (int64, error) {
 		return 0, err
 	}
 
-	mntFolder, err := ioutil.TempDir("", "mnt")
+	mntFolder, err := ioutil.TempDir("", "tmp")
 	if err != nil {
 		return 0, err
 	}

--- a/service/gcsutils/tarlib/tardisk.go
+++ b/service/gcsutils/tarlib/tardisk.go
@@ -126,7 +126,7 @@ func CreateTarDisk(in io.Reader,
 
 	logrus.Info("entering CreateTarDisk")
 
-	mntFolder, err := ioutil.TempDir(tmpdir, "mnt")
+	mntFolder, err := ioutil.TempDir(tmpdir, "tmp")
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
This change is to enable the gcsutils set to be able to work on read-only root filesystem