### PR TITLE
Prepped the CI system for running gcs unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: go
 
 go:
-- 1.8
+- 1.8.3
 
 matrix:
   include:
     - os: linux
 
+services:
+    - docker
+
 sudo: required
 
-script: 
-      - cd service && make 
+script:
+     - cd service && make 
+     - cd gcs && ./run_unittests
 

--- a/service/gcs/run_unittests
+++ b/service/gcs/run_unittests
@@ -1,0 +1,31 @@
+#!/bin/bash -ex 
+
+echo "setting up test environment"
+
+# Set the working directory to the script's directory
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)
+cd $script_dir
+echo "Generate busybox rootfs directory for runC tests"
+rootfs=runtime/runc/testbundle/rootfs
+mkdir -p $rootfs
+sudo mkdir -p /var/run/gcsrunc
+sudo docker export $(sudo docker create busybox) | tar -C $rootfs -xvf - > /dev/null
+
+echo "clone opencontailers/runc repo and build runc binary"
+
+cd $GOPATH/src/github.com
+mkdir opencontainers && cd opencontainers
+git clone https://github.com/opencontainers/runc runc
+cd runc && git checkout 992a5be178a62e026f4069f443c6164912adbf09
+make BUILDTAGS=``
+sudo cp ./runc /bin/runc
+/bin/runc -version
+
+echo "install Ginkgo"
+go get github.com/onsi/ginkgo/ginkgo
+
+#echo "start running unittest cases"
+#cd $GOPATH/src/github.com/Microsoft/opengcs/service/gcs
+#ginkgo -r -race
+
+


### PR DESCRIPTION
Changes include: update Golang from 1.8 to 1.8.3 in in the CI system
Added a run_unittests script for setting up the unttest execution environment (install Runc, creating required directories, and pick up test framework package)