### PR TITLE
Updated build instructions for the addition of the new netnscfg tool

### DIFF
--- a/docs/customosbuildinstructions.md
+++ b/docs/customosbuildinstructions.md
@@ -94,8 +94,9 @@ Here are the expected contents of each subdirectory /file
             /bin/tar2vhd
             /bin/exportSandbox
             /bin/createSandbox
+            /bin/netnscfg
 
-            Note : exportSandbox, createSandbox, vhd2tar, and tar2vhd  are actually hard links to the file gcstools
+            Note : exportSandbox, createSandbox, vhd2tar, tar2vhd, and netnscfg are actually hard links to the file gcstools
 
     - Required binaires: utilities used by gcs
 

--- a/docs/gcsbuildinstructions.md
+++ b/docs/gcsbuildinstructions.md
@@ -32,5 +32,5 @@
 
     eg: On a successful build, you would get the following binaries
     root@ubuntu:~/golang/src/github.com/Microsoft/opengcs/service# ls  bin
-    createSandbox  exportSandbox  gcs  gcstools  tar2vhd  vhd2tar
+    createSandbox  exportSandbox  gcs  gcstools  tar2vhd  vhd2tar netnscfg
 


### PR DESCRIPTION
This doc update is to keep in sync with the latest from code changes for introducing netnscfg to the gcstools set