### PR TITLE
Change TerminateProcess to SignalProcess

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -101,9 +101,9 @@ func (b *bridge) loop() error {
 			if err != nil {
 				logrus.Error(err)
 			}
-		case prot.ComputeSystemTerminateProcessV1:
-			logrus.Info("received from HCS: ComputeSystemTerminateProcessV1")
-			response, err = b.terminateProcess(message)
+		case prot.ComputeSystemSignalProcessV1:
+			logrus.Info("received from HCS: ComputeSystemSignalProcessV1")
+			response, err = b.signalProcess(message)
 			if err != nil {
 				logrus.Error(err)
 			}
@@ -268,15 +268,15 @@ func (b *bridge) shutdownContainer(message []byte) (*prot.MessageResponseBase, e
 	return response, nil
 }
 
-func (b *bridge) terminateProcess(message []byte) (*prot.MessageResponseBase, error) {
+func (b *bridge) signalProcess(message []byte) (*prot.MessageResponseBase, error) {
 	response := newResponseBase()
-	var request prot.ContainerTerminateProcess
+	var request prot.ContainerSignalProcess
 	if err := commonutils.UnmarshalJSONWithHresult(message, &request); err != nil {
 		return response, errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", message)
 	}
 	response.ActivityID = request.ActivityID
 
-	if err := b.coreint.TerminateProcess(int(request.ProcessID)); err != nil {
+	if err := b.coreint.SignalProcess(int(request.ProcessID), request.Options); err != nil {
 		return response, err
 	}
 

--- a/service/gcs/core/core.go
+++ b/service/gcs/core/core.go
@@ -16,7 +16,7 @@ type Core interface {
 	CreateContainer(id string, info prot.VMHostedContainerSettings) error
 	ExecProcess(id string, info prot.ProcessParameters, stdioSet *stdio.ConnectionSet) (pid int, err error)
 	SignalContainer(id string, signal oslayer.Signal) error
-	TerminateProcess(pid int) error
+	SignalProcess(pid int, options prot.SignalProcessOptions) error
 	ListProcesses(id string) ([]runtime.ContainerProcessState, error)
 	RunExternalProcess(info prot.ProcessParameters, stdioSet *stdio.ConnectionSet) (pid int, err error)
 	ModifySettings(id string, request prot.ResourceModificationRequestResponse) error

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -2,6 +2,7 @@ package gcs
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/mockos"
@@ -845,9 +846,15 @@ var _ = Describe("GCS", func() {
 					})
 				})
 			})
-			Describe("calling TerminateProcess", func() {
+			Describe("calling SignalProcess", func() {
+				var (
+					sigkillOptions prot.SignalProcessOptions
+				)
+				BeforeEach(func() {
+					sigkillOptions = prot.SignalProcessOptions{Signal: int32(syscall.SIGKILL)}
+				})
 				JustBeforeEach(func() {
-					err = coreint.TerminateProcess(processID)
+					err = coreint.SignalProcess(processID, sigkillOptions)
 				})
 				Context("the process has already been created", func() {
 					BeforeEach(func() {

--- a/service/gcs/core/mockcore/mockcore.go
+++ b/service/gcs/core/mockcore/mockcore.go
@@ -28,9 +28,10 @@ type SignalContainerCall struct {
 	Signal oslayer.Signal
 }
 
-// TerminateProcessCall captures the arguments of TerminateProcess.
-type TerminateProcessCall struct {
-	Pid int
+// SignalProcessCall captures the arguments of SignalProcess.
+type SignalProcessCall struct {
+	Pid     int
+	Options prot.SignalProcessOptions
 }
 
 // ListProcessesCall captures the arguments of ListProcesses.
@@ -71,7 +72,7 @@ type MockCore struct {
 	LastCreateContainer           CreateContainerCall
 	LastExecProcess               ExecProcessCall
 	LastSignalContainer           SignalContainerCall
-	LastTerminateProcess          TerminateProcessCall
+	LastSignalProcess             SignalProcessCall
 	LastListProcesses             ListProcessesCall
 	LastRunExternalProcess        RunExternalProcessCall
 	LastModifySettings            ModifySettingsCall
@@ -104,9 +105,12 @@ func (c *MockCore) SignalContainer(id string, signal oslayer.Signal) error {
 	return nil
 }
 
-// TerminateProcess captures its arguments and returns a nil error.
-func (c *MockCore) TerminateProcess(pid int) error {
-	c.LastTerminateProcess = TerminateProcessCall{Pid: pid}
+// SignalProcess captures its arguments and returns a nil error.
+func (c *MockCore) SignalProcess(pid int, options prot.SignalProcessOptions) error {
+	c.LastSignalProcess = SignalProcessCall{
+		Pid:     pid,
+		Options: options,
+	}
 	return nil
 }
 

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -73,7 +73,7 @@ const (
 	ComputeSystemShutdownForcedV1   = 0x10100401
 	ComputeSystemExecuteProcessV1   = 0x10100501
 	ComputeSystemWaitForProcessV1   = 0x10100601
-	ComputeSystemTerminateProcessV1 = 0x10100701
+	ComputeSystemSignalProcessV1    = 0x10100701
 	ComputeSystemResizeConsoleV1    = 0x10100801
 	ComputeSystemGetPropertiesV1    = 0x10100901
 	ComputeSystemModifySettingsV1   = 0x10100a01
@@ -85,7 +85,7 @@ const (
 	ComputeSystemResponseShutdownForcedV1   = 0x20100401
 	ComputeSystemResponseExecuteProcessV1   = 0x20100501
 	ComputeSystemResponseWaitForProcessV1   = 0x20100601
-	ComputeSystemResponseTerminateProcessV1 = 0x20100701
+	ComputeSystemResponseSignalProcessV1    = 0x20100701
 	ComputeSystemResponseResizeConsoleV1    = 0x20100801
 	ComputeSystemResponseGetPropertiesV1    = 0x20100901
 	ComputeSystemResponseModifySettingsV1   = 0x20100a01
@@ -225,11 +225,12 @@ type ContainerWaitForProcess struct {
 	TimeoutInMs uint32
 }
 
-// ContainerTerminateProcess is the message from the HCS specifying to kill the
-// given process.
-type ContainerTerminateProcess struct {
+// ContainerSignalProcess is the message from the HCS specifying to send a
+// signal to the given process.
+type ContainerSignalProcess struct {
 	*MessageBase
-	ProcessID uint32 `json:"ProcessId"`
+	ProcessID uint32               `json:"ProcessId"`
+	Options   SignalProcessOptions `json:",omitempty"`
 }
 
 // ContainerGetProperties is the message from the HCS requesting certain
@@ -473,4 +474,9 @@ type ProcessParameters struct {
 	// be specified. Otherwise, it must be left blank and the other fields must
 	// be specified.
 	OCISpecification oci.Spec `json:"OciSpecification,omitempty"`
+}
+
+// SignalProcessOptions represents the options for signaling a process.
+type SignalProcessOptions struct {
+	Signal int32
 }


### PR DESCRIPTION
Now the GCS will receive a SignalProcessOptions field in the
ContainerSignalProcess message (which was renamed from
ContainerTerminateProcess). Rather than sending a SIGTERM to the process
followed by a SIGKILL after a timeout, the GCS will simply send the
specified signal to the process. Renaming has also been done throughout
the code to match this semantic change.