### PR TITLE
Updated user mode preparation instructions in response to the removal 

### DIFF
--- a/docs/customosbuildinstructions.md
+++ b/docs/customosbuildinstructions.md
@@ -84,13 +84,15 @@ Here are the expected contents of each subdirectory /file
         
     - [GCS binaries](gcsbuildinstructions.md/)
 
+            /bin/exportSandbox
             /bin/gcs
             /bin/gcstools
-            /bin/vhd2tar
+            /bin/netnscfg
+            /bin/remotefs
             /bin/tar2vhd
-            /bin/exportSandbox
+            /bin/vhd2tar
 
-            Note : exportSandbox, vhd2tar and tar2vhd are actually hard links to the file gcstools
+            Note : exportSandbox, vhd2tar, tar2vhd, remotefs, and netnscfg  are actually hard links to the "gcstools' file
 
     - Required binaires: utilities used by gcs
 


### PR DESCRIPTION
... of prebuiltsandbox.vhdx from the requirement
Any custom Linux OS built for LCOW without prebuildSandbox.vhdx can work with a DockerD binary only if it includes the following moby/moby commit.
moby/moby@a3ffc42