### PR TITLE
Support responses with both error messages and stack traces

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -407,13 +407,13 @@ func newResponseBase() *prot.MessageResponseBase {
 // contain information pertaining to the given error.
 func (b *bridge) setErrorForResponseBase(response *prot.MessageResponseBase, errForResponse error) {
 	errorMessage := errForResponse.Error()
+	stackString := ""
 	fileName := ""
 	lineNumber := -1
 	functionName := ""
-	if serr, ok := errForResponse.(gcserr.StackTracer); ok {
-		frames := serr.StackTrace()
-		bottomFrame := frames[0]
-		errorMessage = fmt.Sprintf("%+v", serr)
+	if stack := gcserr.BaseStackTrace(errForResponse); stack != nil {
+		bottomFrame := stack[0]
+		stackString = fmt.Sprintf("%+v", stack)
 		fileName = fmt.Sprintf("%s", bottomFrame)
 		lineNumberStr := fmt.Sprintf("%d", bottomFrame)
 		var err error
@@ -433,6 +433,7 @@ func (b *bridge) setErrorForResponseBase(response *prot.MessageResponseBase, err
 	newRecord := prot.ErrorRecord{
 		Result:       int32(hresult),
 		Message:      errorMessage,
+		StackTrace:   stackString,
 		ModuleName:   "gcs",
 		FileName:     fileName,
 		Line:         uint32(lineNumber),

--- a/service/gcs/errors/errors_test.go
+++ b/service/gcs/errors/errors_test.go
@@ -23,6 +23,57 @@ type stackTraceCauseError interface {
 
 var _ = Describe("Errors", func() {
 	Describe("unittests", func() {
+		Describe("getting the base stack trace", func() {
+			Context("only one error in cause stack", func() {
+				var (
+					e          error
+					stackTrace errors.StackTrace
+				)
+				BeforeEach(func() {
+					e = errors.New("test")
+					stackTrace = BaseStackTrace(e)
+				})
+				It("should return the same stack trace as the single error", func() {
+					se, ok := e.(StackTracer)
+					Expect(ok).To(BeTrue())
+					Expect(stackTrace).To(Equal(se.StackTrace()))
+				})
+			})
+			Context("multiple StackTracers in cause stack", func() {
+				var (
+					e1         error
+					e2         error
+					e3         error
+					e4         error
+					stackTrace errors.StackTrace
+				)
+				BeforeEach(func() {
+					e1 = fmt.Errorf("test")
+					e2 = errors.WithStack(e1)
+					e3 = errors.WithStack(e2)
+					e4 = errors.WithMessage(e3, "test2")
+					stackTrace = BaseStackTrace(e4)
+				})
+				It("should return the same stack trace as the bottom-most StackTracer", func() {
+					se, ok := e2.(StackTracer)
+					Expect(ok).To(BeTrue())
+					Expect(stackTrace).To(Equal(se.StackTrace()))
+				})
+			})
+			Context("no StackTracers in cause stack", func() {
+				var (
+					e          error
+					stackTrace errors.StackTrace
+				)
+				BeforeEach(func() {
+					e = fmt.Errorf("test")
+					stackTrace = BaseStackTrace(e)
+				})
+				It("should return nil", func() {
+					Expect(stackTrace).To(BeNil())
+				})
+			})
+		})
 		Describe("constructing HRESULT errors", func() {
 			Context("with no wrapped error", func() {
 				var (

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -335,10 +335,11 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 
 // ErrorRecord represents a single error to be reported back to the HCS. It
 // allows for specifying information about the source of the error, as well as
-// an error message.
+// an error message and stack trace.
 type ErrorRecord struct {
 	Result       int32
 	Message      string
+	StackTrace   string `json:",omitempty"`
 	ModuleName   string
 	FileName     string
 	Line         uint32


### PR DESCRIPTION
The HCS now can accept stack trace information in the ErrorRecord
struct. As a result, the GCS should provide that information back on
error.