### PR TITLE
Change permissions of etc directory from 0700 to 0755

### DIFF
--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -175,7 +175,7 @@ func (c *gcsCore) CreateContainer(id string, settings prot.VMHostedContainerSett
 	// supposed to be read-only layer in the overlay...  Ideally,
 	// dockerd would pass a runc config with a bind mount for
 	// /etc/resolv.conf like it does on unix.
-	if err := c.OS.MkdirAll(filepath.Join(baseFilesPath, "etc"), 0700); err != nil {
+	if err := c.OS.MkdirAll(filepath.Join(baseFilesPath, "etc"), 0755); err != nil {
 		return errors.Wrapf(err, "failed to create resolv.conf directory")
 	}
 


### PR DESCRIPTION
This fixes an issue experienced in the ubuntu image where apt-get needs
the /etc directory to be executable to perform an nslookup. When we
switch to using bind mounts specified by docker to get resolv.conf into
the container namespace, we might be able to avoid specifying the
permission bits altogether.