### PR TITLE
updated gcs to oci  v1.0.0

### DIFF
--- a/service/gcs/bridge/bridge_test.go
+++ b/service/gcs/bridge/bridge_test.go
@@ -267,21 +267,20 @@ var _ = Describe("Bridge", func() {
 							CreateStdErrPipe: true,
 							IsExternal:       false,
 							OCISpecification: oci.Spec{
-								Version:  "1.0.0-rc5-dev",
-								Platform: oci.Platform{OS: "linux", Arch: "amd64"},
-								Process: oci.Process{
+								Version:  "1.0.0",
+								Process: &oci.Process{
 									Terminal:        true,
 									User:            oci.User{UID: 1001, GID: 1001, AdditionalGids: []uint32{0, 1, 2}},
 									Args:            []string{"sh", "-c", "testexe"},
 									Env:             []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm"},
 									Cwd:             "/bin",
 									Capabilities:    &oci.LinuxCapabilities{Bounding: []string{"CAP_AUDIT_WRITE", "CAP_KILL", "CAP_NET_BIND_SERVICE"}},
-									Rlimits:         []oci.LinuxRlimit{oci.LinuxRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024}},
+									Rlimits:         []oci.POSIXRlimit{oci.POSIXRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024}},
 									NoNewPrivileges: true,
 									ApparmorProfile: "testing",
 									SelinuxLabel:    "testing",
 								},
-								Root:     oci.Root{Path: "rootfs", Readonly: true},
+								Root:     &oci.Root{Path: "rootfs", Readonly: true},
 								Hostname: "test",
 								Mounts:   []oci.Mount{oci.Mount{Destination: "/dev", Type: "tmpfs", Source: "tmpfs", Options: []string{"nosuid"}}},
 								Hooks: &oci.Hooks{

--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -643,7 +643,7 @@ func (c *gcsCore) removeMappedDirectories(id string, dirs []prot.MappedDirectory
 }
 
 // processParametersToOCI converts the given ProcessParameters struct into an
-// oci.Process struct for OCI version 1.0.0-rc5-dev. Since ProcessParameters
+// oci.Process struct for OCI version 1.0.0. Since ProcessParameters
 // doesn't include various fields which are available in oci.Process, default
 // values for these fields are chosen.
 func processParametersToOCI(params prot.ProcessParameters) (oci.Process, error) {
@@ -733,8 +733,8 @@ func processParametersToOCI(params prot.ProcessParameters) (oci.Process, error) 
 				"CAP_NET_RAW",
 			},
 		},
-		Rlimits: []oci.LinuxRlimit{
-			oci.LinuxRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
+		Rlimits: []oci.POSIXRlimit{
+			oci.POSIXRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
 		},
 		NoNewPrivileges: true,
 	}, nil

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -115,8 +115,8 @@ var _ = Describe("GCS", func() {
 								"CAP_NET_RAW",
 							},
 						},
-						Rlimits: []oci.LinuxRlimit{
-							oci.LinuxRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
+						Rlimits: []oci.POSIXRlimit{
+							oci.POSIXRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
 						},
 						NoNewPrivileges: true,
 					}))
@@ -213,8 +213,8 @@ var _ = Describe("GCS", func() {
 								"CAP_NET_RAW",
 							},
 						},
-						Rlimits: []oci.LinuxRlimit{
-							oci.LinuxRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
+						Rlimits: []oci.POSIXRlimit{
+							oci.POSIXRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
 						},
 						NoNewPrivileges: true,
 					}))
@@ -311,8 +311,8 @@ var _ = Describe("GCS", func() {
 								"CAP_NET_RAW",
 							},
 						},
-						Rlimits: []oci.LinuxRlimit{
-							oci.LinuxRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
+						Rlimits: []oci.POSIXRlimit{
+							oci.POSIXRlimit{Type: "RLIMIT_NOFILE", Hard: 1024, Soft: 1024},
 						},
 						NoNewPrivileges: true,
 					}))

--- a/service/gcs/runtime/runc/cat_config.json
+++ b/service/gcs/runtime/runc/cat_config.json
@@ -1,5 +1,5 @@
 {
-	"ociVersion": "1.0.0-rc5",
+	"ociVersion": "1.0.0",
 	"platform": {
 		"os": "linux",
 		"arch": "amd64"

--- a/service/gcs/runtime/runc/err_config.json
+++ b/service/gcs/runtime/runc/err_config.json
@@ -1,5 +1,5 @@
 {
-	"ociVersion": "1.0.0-rc5",
+	"ociVersion": "1.0.0",
 	"platform": {
 		"os": "linux",
 		"arch": "amd64"

--- a/service/gcs/runtime/runc/sh_config.json
+++ b/service/gcs/runtime/runc/sh_config.json
@@ -1,5 +1,5 @@
 {
-	"ociVersion": "1.0.0-rc5",
+	"ociVersion": "1.0.0",
 	"platform": {
 		"os": "linux",
 		"arch": "amd64"

--- a/service/gcs/runtime/runc/sleep_config.json
+++ b/service/gcs/runtime/runc/sleep_config.json
@@ -1,5 +1,5 @@
 {
-	"ociVersion": "1.0.0-rc5",
+	"ociVersion": "1.0.0",
 	"platform": {
 		"os": "linux",
 		"arch": "amd64"

--- a/service/gcs/setup_test_env
+++ b/service/gcs/setup_test_env
@@ -10,7 +10,7 @@ go get github.com/onsi/ginkgo/ginkgo
 # Install runc
 go get -d github.com/opencontainers/runc
 cd $GOPATH/src/github.com/opencontainers/runc
-git checkout 992a5be178a62e026f4069f443c6164912adbf09
+git checkout 882d8eaba6682179e397c78d5a40e45fa4d571ce
 go install github.com/opencontainers/runc
 cd $script_dir
 

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -6,26 +6,24 @@ import "os"
 type Spec struct {
 	// Version of the Open Container Runtime Specification with which the bundle complies.
 	Version string `json:"ociVersion"`
-	// Platform specifies the configuration's target platform.
-	Platform Platform `json:"platform"`
 	// Process configures the container process.
-	Process Process `json:"process"`
+	Process *Process `json:"process,omitempty"`
 	// Root configures the container's root filesystem.
-	Root Root `json:"root"`
+	Root *Root `json:"root,omitempty"`
 	// Hostname configures the container's hostname.
 	Hostname string `json:"hostname,omitempty"`
 	// Mounts configures additional mounts (on top of Root).
 	Mounts []Mount `json:"mounts,omitempty"`
 	// Hooks configures callbacks for container lifecycle events.
-	Hooks *Hooks `json:"hooks,omitempty"`
+	Hooks *Hooks `json:"hooks,omitempty" platform:"linux,solaris"`
 	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// Linux is platform specific configuration for Linux based containers.
+	// Linux is platform-specific configuration for Linux based containers.
 	Linux *Linux `json:"linux,omitempty" platform:"linux"`
-	// Solaris is platform specific configuration for Solaris containers.
+	// Solaris is platform-specific configuration for Solaris based containers.
 	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
-	// Windows is platform specific configuration for Windows based containers, including Hyper-V containers.
+	// Windows is platform-specific configuration for Windows based containers.
 	Windows *Windows `json:"windows,omitempty" platform:"windows"`
 }
 
@@ -34,7 +32,7 @@ type Process struct {
 	// Terminal creates an interactive terminal for the container.
 	Terminal bool `json:"terminal,omitempty"`
 	// ConsoleSize specifies the size of the console.
-	ConsoleSize Box `json:"consoleSize,omitempty"`
+	ConsoleSize *Box `json:"consoleSize,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
@@ -47,11 +45,13 @@ type Process struct {
 	// Capabilities are Linux capabilities that are kept for the process.
 	Capabilities *LinuxCapabilities `json:"capabilities,omitempty" platform:"linux"`
 	// Rlimits specifies rlimit options to apply to the process.
-	Rlimits []LinuxRlimit `json:"rlimits,omitempty" platform:"linux"`
+	Rlimits []POSIXRlimit `json:"rlimits,omitempty" platform:"linux,solaris"`
 	// NoNewPrivileges controls whether additional privileges could be gained by processes in the container.
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
+	// Specify an oom_score_adj for the container.
+	OOMScoreAdj *int `json:"oomScoreAdj,omitempty" platform:"linux"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
@@ -99,23 +99,13 @@ type Root struct {
 	Readonly bool `json:"readonly,omitempty"`
 }
 
-// Platform specifies OS and arch information for the host system that the container
-// is created for.
-type Platform struct {
-	// OS is the operating system.
-	OS string `json:"os"`
-	// Arch is the architecture
-	Arch string `json:"arch"`
-}
-
 // Mount specifies a mount for a container.
 type Mount struct {
-	// Destination is the path where the mount will be placed relative to the container's root.  The path and child directories MUST exist, a runtime MUST NOT create directories automatically to a mount point.
+	// Destination is the absolute path where the mount will be placed in the container.
 	Destination string `json:"destination"`
 	// Type specifies the mount kind.
-	Type string `json:"type,omitempty"`
-	// Source specifies the source path of the mount.  In the case of bind mounts on
-	// Linux based systems this would be the file on the host.
+	Type string `json:"type,omitempty" platform:"linux,solaris"`
+	// Source specifies the source path of the mount.
 	Source string `json:"source,omitempty"`
 	// Options are fstab style mount options.
 	Options []string `json:"options,omitempty"`
@@ -132,7 +122,6 @@ type Hook struct {
 // Hooks for container setup and teardown
 type Hooks struct {
 	// Prestart is a list of hooks to be run before the container process is executed.
-	// On Linux, they are run after the container namespaces are created.
 	Prestart []Hook `json:"prestart,omitempty"`
 	// Poststart is a list of hooks to be run after the container process is started.
 	Poststart []Hook `json:"poststart,omitempty"`
@@ -140,11 +129,11 @@ type Hooks struct {
 	Poststop []Hook `json:"poststop,omitempty"`
 }
 
-// Linux contains platform specific configuration for Linux based containers.
+// Linux contains platform-specific configuration for Linux based containers.
 type Linux struct {
-	// UIDMapping specifies user mappings for supporting user namespaces on Linux.
+	// UIDMapping specifies user mappings for supporting user namespaces.
 	UIDMappings []LinuxIDMapping `json:"uidMappings,omitempty"`
-	// GIDMapping specifies group mappings for supporting user namespaces on Linux.
+	// GIDMapping specifies group mappings for supporting user namespaces.
 	GIDMappings []LinuxIDMapping `json:"gidMappings,omitempty"`
 	// Sysctl are a set of key value pairs that are set for the container on start
 	Sysctl map[string]string `json:"sysctl,omitempty"`
@@ -176,7 +165,7 @@ type Linux struct {
 
 // LinuxNamespace is the configuration for a Linux namespace
 type LinuxNamespace struct {
-	// Type is the type of Linux namespace
+	// Type is the type of namespace
 	Type LinuxNamespaceType `json:"type"`
 	// Path is a path to an existing namespace persisted on disk that can be joined
 	// and is of the same type
@@ -213,8 +202,8 @@ type LinuxIDMapping struct {
 	Size uint32 `json:"size"`
 }
 
-// LinuxRlimit type and restrictions
-type LinuxRlimit struct {
+// POSIXRlimit type and restrictions
+type POSIXRlimit struct {
 	// Type of the rlimit to set
 	Type string `json:"type"`
 	// Hard is the hard limit for the specified type
@@ -247,7 +236,7 @@ type linuxBlockIODevice struct {
 	Minor int64 `json:"minor"`
 }
 
-// LinuxWeightDevice struct holds a `major:minor weight` pair for blkioWeightDevice
+// LinuxWeightDevice struct holds a `major:minor weight` pair for weightDevice
 type LinuxWeightDevice struct {
 	linuxBlockIODevice
 	// Weight is the bandwidth rate for the device.
@@ -266,35 +255,37 @@ type LinuxThrottleDevice struct {
 // LinuxBlockIO for Linux cgroup 'blkio' resource management
 type LinuxBlockIO struct {
 	// Specifies per cgroup weight
-	Weight *uint16 `json:"blkioWeight,omitempty"`
+	Weight *uint16 `json:"weight,omitempty"`
 	// Specifies tasks' weight in the given cgroup while competing with the cgroup's child cgroups, CFQ scheduler only
-	LeafWeight *uint16 `json:"blkioLeafWeight,omitempty"`
+	LeafWeight *uint16 `json:"leafWeight,omitempty"`
 	// Weight per cgroup per device, can override BlkioWeight
-	WeightDevice []LinuxWeightDevice `json:"blkioWeightDevice,omitempty"`
+	WeightDevice []LinuxWeightDevice `json:"weightDevice,omitempty"`
 	// IO read rate limit per cgroup per device, bytes per second
-	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"blkioThrottleReadBpsDevice,omitempty"`
+	ThrottleReadBpsDevice []LinuxThrottleDevice `json:"throttleReadBpsDevice,omitempty"`
 	// IO write rate limit per cgroup per device, bytes per second
-	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"blkioThrottleWriteBpsDevice,omitempty"`
+	ThrottleWriteBpsDevice []LinuxThrottleDevice `json:"throttleWriteBpsDevice,omitempty"`
 	// IO read rate limit per cgroup per device, IO per second
-	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleReadIOPSDevice,omitempty"`
+	ThrottleReadIOPSDevice []LinuxThrottleDevice `json:"throttleReadIOPSDevice,omitempty"`
 	// IO write rate limit per cgroup per device, IO per second
-	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"blkioThrottleWriteIOPSDevice,omitempty"`
+	ThrottleWriteIOPSDevice []LinuxThrottleDevice `json:"throttleWriteIOPSDevice,omitempty"`
 }
 
 // LinuxMemory for Linux cgroup 'memory' resource management
 type LinuxMemory struct {
 	// Memory limit (in bytes).
-	Limit *uint64 `json:"limit,omitempty"`
+	Limit *int64 `json:"limit,omitempty"`
 	// Memory reservation or soft_limit (in bytes).
-	Reservation *uint64 `json:"reservation,omitempty"`
+	Reservation *int64 `json:"reservation,omitempty"`
 	// Total memory limit (memory + swap).
-	Swap *uint64 `json:"swap,omitempty"`
+	Swap *int64 `json:"swap,omitempty"`
 	// Kernel memory limit (in bytes).
-	Kernel *uint64 `json:"kernel,omitempty"`
+	Kernel *int64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
-	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
-	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
+	KernelTCP *int64 `json:"kernelTCP,omitempty"`
+	// How aggressive the kernel will swap memory pages.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
+	// DisableOOMKiller disables the OOM killer for out of memory conditions
+	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
 }
 
 // LinuxCPU for Linux cgroup 'cpu' resource management
@@ -333,10 +324,6 @@ type LinuxNetwork struct {
 type LinuxResources struct {
 	// Devices configures the device whitelist.
 	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
-	// DisableOOMKiller disables the OOM killer for out of memory conditions
-	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
-	// Specify an oom_score_adj for the container.
-	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
 	// Memory restriction configuration
 	Memory *LinuxMemory `json:"memory,omitempty"`
 	// CPU resource restriction configuration
@@ -383,7 +370,7 @@ type LinuxDeviceCgroup struct {
 	Access string `json:"access,omitempty"`
 }
 
-// Solaris contains platform specific configuration for Solaris application containers.
+// Solaris contains platform-specific configuration for Solaris application containers.
 type Solaris struct {
 	// SMF FMRI which should go "online" before we start the container process.
 	Milestone string `json:"milestone,omitempty"`
@@ -430,8 +417,20 @@ type SolarisAnet struct {
 
 // Windows defines the runtime configuration for Windows based containers, including Hyper-V containers.
 type Windows struct {
+	// LayerFolders contains a list of absolute paths to directories containing image layers.
+	LayerFolders []string `json:"layerFolders"`
 	// Resources contains information for handling resource constraints for the container.
 	Resources *WindowsResources `json:"resources,omitempty"`
+	// CredentialSpec contains a JSON object describing a group Managed Service Account (gMSA) specification.
+	CredentialSpec interface{} `json:"credentialSpec,omitempty"`
+	// Servicing indicates if the container is being started in a mode to apply a Windows Update servicing operation.
+	Servicing bool `json:"servicing,omitempty"`
+	// IgnoreFlushesDuringBoot indicates if the container is being started in a mode where disk writes are not flushed during its boot process.
+	IgnoreFlushesDuringBoot bool `json:"ignoreFlushesDuringBoot,omitempty"`
+	// HyperV contains information for running a container with Hyper-V isolation.
+	HyperV *WindowsHyperV `json:"hyperv,omitempty"`
+	// Network restriction configuration.
+	Network *WindowsNetwork `json:"network,omitempty"`
 }
 
 // WindowsResources has container runtime resource constraints for containers running on Windows.
@@ -442,23 +441,19 @@ type WindowsResources struct {
 	CPU *WindowsCPUResources `json:"cpu,omitempty"`
 	// Storage restriction configuration.
 	Storage *WindowsStorageResources `json:"storage,omitempty"`
-	// Network restriction configuration.
-	Network *WindowsNetworkResources `json:"network,omitempty"`
 }
 
 // WindowsMemoryResources contains memory resource management settings.
 type WindowsMemoryResources struct {
 	// Memory limit in bytes.
 	Limit *uint64 `json:"limit,omitempty"`
-	// Memory reservation in bytes.
-	Reservation *uint64 `json:"reservation,omitempty"`
 }
 
 // WindowsCPUResources contains CPU resource management settings.
 type WindowsCPUResources struct {
 	// Number of CPUs available to the container.
 	Count *uint64 `json:"count,omitempty"`
-	// CPU shares (relative weight to other containers with cpu shares). Range is from 1 to 10000.
+	// CPU shares (relative weight to other containers with cpu shares).
 	Shares *uint16 `json:"shares,omitempty"`
 	// Specifies the portion of processor cycles that this container can use as a percentage times 100.
 	Maximum *uint16 `json:"maximum,omitempty"`
@@ -474,10 +469,22 @@ type WindowsStorageResources struct {
 	SandboxSize *uint64 `json:"sandboxSize,omitempty"`
 }
 
-// WindowsNetworkResources contains network resource management settings.
-type WindowsNetworkResources struct {
-	// EgressBandwidth is the maximum egress bandwidth in bytes per second.
-	EgressBandwidth *uint64 `json:"egressBandwidth,omitempty"`
+// WindowsNetwork contains network settings for Windows containers.
+type WindowsNetwork struct {
+	// List of HNS endpoints that the container should connect to.
+	EndpointList []string `json:"endpointList,omitempty"`
+	// Specifies if unqualified DNS name resolution is allowed.
+	AllowUnqualifiedDNSQuery bool `json:"allowUnqualifiedDNSQuery,omitempty"`
+	// Comma separated list of DNS suffixes to use for name resolution.
+	DNSSearchList []string `json:"DNSSearchList,omitempty"`
+	// Name (ID) of the container that we will share with the network stack.
+	NetworkSharedContainerName string `json:"networkSharedContainerName,omitempty"`
+}
+
+// WindowsHyperV contains information for configuring a container to run with Hyper-V isolation.
+type WindowsHyperV struct {
+	// UtilityVMPath is an optional path to the image used for the Utility VM.
+	UtilityVMPath string `json:"utilityVMPath,omitempty"`
 }
 
 // LinuxSeccomp represents syscall restrictions
@@ -543,7 +550,7 @@ const (
 type LinuxSeccompArg struct {
 	Index    uint                 `json:"index"`
 	Value    uint64               `json:"value"`
-	ValueTwo uint64               `json:"valueTwo"`
+	ValueTwo uint64               `json:"valueTwo,omitempty"`
 	Op       LinuxSeccompOperator `json:"op"`
 }
 

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/state.go
@@ -9,7 +9,7 @@ type State struct {
 	// Status is the runtime status of the container.
 	Status string `json:"status"`
 	// Pid is the process ID for the container process.
-	Pid int `json:"pid"`
+	Pid int `json:"pid,omitempty"`
 	// Bundle is the path to the container's bundle directory.
 	Bundle string `json:"bundle"`
 	// Annotations are key values associated with the container.

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/version.go
@@ -11,7 +11,7 @@ const (
 	VersionPatch = 0
 
 	// VersionDev indicates development branch. Releases will be empty string.
-	VersionDev = "-rc5-dev"
+	VersionDev = ""
 )
 
 // Version is the specification version that the package types support.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -287,10 +287,10 @@
 			"revisionTime": "2017-06-07T17:51:42Z"
 		},
 		{
-			"checksumSHA1": "QhJaqD0QC5PXXG5hQ++2jN3Q9G0=",
+			"checksumSHA1": "AMYc2X2O/IL6EGrq6lTl5vEhLiY=",
 			"path": "github.com/opencontainers/runtime-spec/specs-go",
-			"revision": "d42f1eb741e6361e858d83fc75aa6893b66292c4",
-			"revisionTime": "2017-05-08T21:35:35Z"
+			"revision": "02137cd4e50b37a01665e1731fcd4ac2d2178230",
+			"revisionTime": "2017-07-12T14:33:56Z"
 		},
 		{
 			"checksumSHA1": "rJab1YdNhQooDiBWNnt7TLWPyBU=",


### PR DESCRIPTION
This PR includes all changes needed to switch GCS from using OCI V1.0.0-rc5dev to OCI V1.0.0