### PR TITLE
gcs: Mount plan9 shares with fd transport

### DIFF
--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/runtime/mockruntime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
+	"github.com/Microsoft/opengcs/service/gcs/transport"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
@@ -585,7 +586,7 @@ var _ = Describe("GCS", func() {
 			BeforeEach(func() {
 				rtime := mockruntime.NewRuntime()
 				os := mockos.NewOS()
-				coreint = NewGCSCore(rtime, os)
+				coreint = NewGCSCore(rtime, os, &transport.MockTransport{})
 				containerID = "01234567-89ab-cdef-0123-456789abcdef"
 				processID = 101
 				createSettings = prot.VMHostedContainerSettings{

--- a/service/gcs/core/gcs/storage_test.go
+++ b/service/gcs/core/gcs/storage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Microsoft/opengcs/service/gcs/oslayer/realos"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime/runc"
+	"github.com/Microsoft/opengcs/service/gcs/transport"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -25,7 +26,7 @@ var _ = Describe("Storage", func() {
 		rtime, err := runc.NewRuntime()
 		Expect(err).NotTo(HaveOccurred())
 		os := realos.NewOS()
-		coreint = NewGCSCore(rtime, os)
+		coreint = NewGCSCore(rtime, os, &transport.MockTransport{})
 	})
 
 	Describe("getting the container paths", func() {

--- a/service/gcs/main.go
+++ b/service/gcs/main.go
@@ -55,7 +55,7 @@ func main() {
 		logrus.Fatalf("%+v", err)
 	}
 	os := realos.NewOS()
-	coreint := gcs.NewGCSCore(rtime, os)
+	coreint := gcs.NewGCSCore(rtime, os, tport)
 	mux := bridge.NewBridgeMux()
 	b := bridge.Bridge{
 		Transport: tport,

--- a/service/gcs/transport/mock.go
+++ b/service/gcs/transport/mock.go
@@ -56,9 +56,14 @@ func (t *MockTransport) Dial(_ uint32) (_ Connection, err error) {
 		return nil, errors.New("client connection was not a unix socket")
 	}
 
-	t.Channel <- &MockConnection{
-		UnixConn: serverUnixConn,
+	if t.Channel != nil {
+		t.Channel <- &MockConnection{
+			UnixConn: serverUnixConn,
+		}
+	} else {
+		serverUnixConn.Close()
 	}
+
 	return &MockConnection{
 		UnixConn: clientUnixConn,
 	}, nil


### PR DESCRIPTION
This change eliminates the need for the plan9 vsock transport by
connecting to the plan9 server in GCS and using the plan9 fd
transport.