### PR TITLE
LCOW: VHDX boot to read-only

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -242,7 +242,7 @@ func (config *Config) StartUtilityVM() error {
 		configuration.HvRuntime = &hcsshim.HvRuntime{
 			ImagePath:          config.Vhdx,
 			BootSource:         "Vhd",
-			WritableBootSource: true,
+			WritableBootSource: false,
 		}
 	} else {
 		configuration.HvRuntime = &hcsshim.HvRuntime{


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@soccergb Fix for #12969254 to mark the VHDX read-only during boot.  Needs a matching follow-up change in docker following this being merged and re-vendored.