### PR TITLE
Enable GCS debugging from docker

### DIFF
--- a/client/createext4vhdx.go
+++ b/client/createext4vhdx.go
@@ -57,6 +57,8 @@ func (config *Config) CreateExt4Vhdx(destFile string, sizeGB uint32, cacheFile s
 		return fmt.Errorf("failed to create VHDx %s: %s", destFile, err)
 	}
 
+	defer config.DebugGCS()
+
 	// Attach it to the utility VM, but don't mount it (as there's no filesystem on it)
 	if err := config.HotAddVhd(destFile, "", false, false); err != nil {
 		return fmt.Errorf("opengcs: CreateExt4Vhdx: failed to hot-add %s to utility VM: %s", cacheFile, err)

--- a/client/hotaddvhd.go
+++ b/client/hotaddvhd.go
@@ -20,6 +20,8 @@ func (config *Config) HotAddVhd(hostPath string, containerPath string, readOnly 
 		return fmt.Errorf("cannot hot-add VHD as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	modification := &hcsshim.ResourceModificationRequestResponse{
 		Resource: "MappedVirtualDisk",
 		Data: hcsshim.MappedVirtualDisk{

--- a/client/hotremovevhd.go
+++ b/client/hotremovevhd.go
@@ -18,6 +18,8 @@ func (config *Config) HotRemoveVhd(hostPath string) error {
 		return fmt.Errorf("cannot hot-add VHD as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	modification := &hcsshim.ResourceModificationRequestResponse{
 		Resource: "MappedVirtualDisk",
 		Data: hcsshim.MappedVirtualDisk{

--- a/client/tartovhd.go
+++ b/client/tartovhd.go
@@ -17,6 +17,8 @@ func (config *Config) TarToVhd(targetVHDFile string, reader io.Reader) (int64, e
 		return 0, fmt.Errorf("cannot Tar2Vhd as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	process, err := config.createUtilsProcess("tar2vhd")
 	if err != nil {
 		return 0, fmt.Errorf("failed to start tar2vhd for %s: %s", targetVHDFile, err)

--- a/client/vhdtotar.go
+++ b/client/vhdtotar.go
@@ -20,6 +20,8 @@ func (config *Config) VhdToTar(vhdFile string, uvmMountPath string, isSandbox bo
 		return nil, fmt.Errorf("cannot VhdToTar as no utility VM is in configuration")
 	}
 
+	defer config.DebugGCS()
+
 	vhdHandle, err := os.Open(vhdFile)
 	if err != nil {
 		return nil, fmt.Errorf("opengcs: VhdToTar: failed to open %s: %s", vhdFile, err)


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jstarks PTAL  @beweedon @juterry75 FYI.

This updates the client code so that docker has some modicum of hope debugging what went wrong inside a utility VM. It's about the best that can be done with the RS3 code base. The commands might need tweaking in the future (such as location change of the runc log), but that's minor.  Below is an example output of the daemon when configured to enable logging doing a simple docker run where I happened to hit the current vsock connect bug, and the retry isn't in there. Already proved it's worth from this alone :) (Note this obviously relies of the GCS being up, and won't capture kernel panics for example).

```
DEBU[2017-09-08T14:29:04.584919700-07:00] HCSShim::Process::WaitTimeout processid=428
DEBU[2017-09-08T14:29:04.585937600-07:00] HCSShim::Process::WaitTimeout succeeded processid=428
DEBU[2017-09-08T14:29:04.585937600-07:00] GCS Debugging:
DEBUG COMMAND: ls -l /tmp
--------------

total 32
drwx------    3 0        0               60 Sep  8 21:29 base
drwxr-xr-x    3 0        0               60 Sep  8 21:29 gcs
-rw-------    1 0        0            28236 Sep  8 21:29 gcs.log
drwxr-xr-x    3 0        0             4096 Sep  8 21:24 scratch



DEBUG COMMAND: cat /tmp/gcs.log
--------------

time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() GCS started"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741824)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741824)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: successfully connected to the HCS via HyperV_Socket\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"ContainerConfig\":\"{\\\"SystemType\\\":\\\"
Container\\\",\\\"Name\\\":\\\"0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm\\\",\\\"HostName\\\":\\\"\\\",\\\"CcgCooki
e\\\":\\\"\\\",\\\"SandboxVolumeLun\\\":0,\\\"SandboxDataPath\\\":\\\"\\\",\\\"Layers\\\":[],\\\"IgnoreFlushesDuringBoot\\\":false,\\\"MappedV
irtualDisks\\\":[{\\\"ContainerPath\\\":\\\"/tmp/scratch\\\",\\\"Lun\\\":2,\\\"CreateInUtilityVM\\\":true}],\\\"TimeZoneInformation\\\":{\\\"B
ias\\\":480,\\\"StandardName\\\":\\\"Pacific Standard Time\\\",\\\"StandardDate\\\":{\\\"Year\\\":0,\\\"Month\\\":11,\\\"DayOfWeek\\\":0,\\\"D
ay\\\":1,\\\"Hour\\\":2,\\\"Minute\\\":0,\\\"Second\\\":0,\\\"Milliseconds\\\":0},\\\"StandardBias\\\":0,\\\"DaylightName\\\":\\\"Pacific Dayl
ight Time\\\",\\\"DaylightDate\\\":{\\\"Year\\\":0,\\\"Month\\\":3,\\\"DayOfWeek\\\":0,\\\"Day\\\":2,\\\"Hour\\\":2,\\\"Minute\\\":0,\\\"Secon
d\\\":0,\\\"Milliseconds\\\":0},\\\"DaylightBias\\\":-60},\\\"VsockStdioPortRange\\\":{\\\"Min\\\":0,\\\"Max\\\":0}}\",\"SupportedVersions\":{
\"MinimumVersion\":\"V2\",\"MaximumVersion\":\"V2\",\"MinimumProtocolVersion\":2,\"MaximumProtocolVersion\":3}}'\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() layerPrefix=/tmp/gcs/0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279
df640000a986d_svm/layer\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() scratchPath:/tmp/gcs/0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279
df640000a986d_svm/scratch\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() workdirPath=/tmp/gcs/0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279
df640000a986d_svm/scratch/work\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() rootfsPath=/tmp/gcs/0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279d
f640000a986d_svm/rootfs\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"SelectedProtocolVersion\":3}' to HCS\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"Request\":{\"ResourceType\":\"MappedVirtualD
isk\",\"Settings\":{\"Lun\":3,\"CreateInUtilityVM\":true,\"AttachOnly\":true}}}'\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\"}' to HCS\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"Settings\":{\"ProcessParameters\":\"{\\\"Com
mandLine\\\":\\\"sh -c \\\\\\\"echo -e 'DEBUG COMMAND: ls -l /tmp\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /tmp;echo -e '\\\\\\\
\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /tmp/gcs.log\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';cat /tmp/gcs.log;echo -
e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /tmp/gcs;
echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs/*\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /
tmp/gcs/*;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /tmp/gcs/*/config.json\\\\\\\\\\\\\\\\n--------------\\\\\\
\\\\\\\\\\n';cat /tmp/gcs/*/config.json;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -lR /var/run/gcsrunc\\\\\\\\\\
\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -lR /var/run/gcsrunc;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /var/
run/gcsrunc/log.log\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';cat /var/run/gcsrunc/log.log;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n'
;echo -e 'DEBUG COMMAND: ps -ef\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ps -ef;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';\\\\\\\"\
\\",\\\"ConsoleSize\\\":[0,0],\\\"CreateInUtilityVm\\\":true,\\\"CreateStdErrPipe\\\":true,\\\"CreateStdInPipe\\\":true,\\\"CreateStdOutPipe\\
\":true,\\\"Environment\\\":{\\\"PATH\\\":\\\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\\\"},\\\"StdErrPipe\\\":\\\"\\\\\\
\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-129\\\",\\\"StdInPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-127\\\",\\\"StdOutPipe\\\":\\\"\
\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-128\\\",\\\"WorkingDirectory\\\":\\\"/bin\\\"}\",\"StdioRelaySettings\":{\"StdIn\":\"00000000-0000-0
000-0000-000000000000\",\"StdOut\":\"00000000-0000-0000-0000-000000000000\",\"StdErr\":\"00000000-0000-0000-0000-000000000000\"},\"VsockStdioR
elaySettings\":{\"StdIn\":1073741952,\"StdOut\":1073741953,\"StdErr\":1073741954}}}'\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741952)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741952)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741953)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741953)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741954)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741954)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"ProcessId\":368}' to HCS\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"ProcessId\":368,\"TimeoutInMs\":4294967295}'
\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() external process 368 exited with exit status 0"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"ExitCode\":0}' to HCS\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"Settings\":{\"ProcessParameters\":\"{\\\"Com
mandLine\\\":\\\"test -d /sys/bus/scsi/devices/0:0:0:3\\\",\\\"ConsoleSize\\\":[0,0],\\\"CreateInUtilityVm\\\":true,\\\"CreateStdErrPipe\\\":t
rue,\\\"CreateStdInPipe\\\":true,\\\"CreateStdOutPipe\\\":true,\\\"Environment\\\":{\\\"PATH\\\":\\\"/usr/local/sbin:/usr/local/bin:/usr/sbin:
/usr/bin:/sbin:/bin:\\\"},\\\"StdErrPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-132\\\",\\\"StdInPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\
\\\\\pipe\\\\\\\\cexec-130\\\",\\\"StdOutPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-131\\\",\\\"WorkingDirectory\\\":\\\"/bin\\\"
}\",\"StdioRelaySettings\":{\"StdIn\":\"00000000-0000-0000-0000-000000000000\",\"StdOut\":\"00000000-0000-0000-0000-000000000000\",\"StdErr\":
\"00000000-0000-0000-0000-000000000000\"},\"VsockStdioRelaySettings\":{\"StdIn\":1073741952,\"StdOut\":1073741953,\"StdErr\":1073741954}}}'\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741952)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741952)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741953)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741953)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741954)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741954)"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() external process 384 exited with exit status 0"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"ProcessId\":384}' to HCS\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"ProcessId\":384,\"TimeoutInMs\":4294967295}'
\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"ExitCode\":0}' to HCS\n"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"Settings\":{\"ProcessParameters\":\"{\\\"Com
mandLine\\\":\\\"ls /sys/bus/scsi/devices/0:0:0:3/block\\\",\\\"ConsoleSize\\\":[0,0],\\\"CreateInUtilityVm\\\":true,\\\"CreateStdErrPipe\\\":
true,\\\"CreateStdInPipe\\\":true,\\\"CreateStdOutPipe\\\":true,\\\"Environment\\\":{\\\"PATH\\\":\\\"/usr/local/sbin:/usr/local/bin:/usr/sbin
:/usr/bin:/sbin:/bin:\\\"},\\\"StdErrPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-135\\\",\\\"StdInPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\
\\\\\\pipe\\\\\\\\cexec-133\\\",\\\"StdOutPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-134\\\",\\\"WorkingDirectory\\\":\\\"/bin\\\
"}\",\"StdioRelaySettings\":{\"StdIn\":\"00000000-0000-0000-0000-000000000000\",\"StdOut\":\"00000000-0000-0000-0000-000000000000\",\"StdErr\"
:\"00000000-0000-0000-0000-000000000000\"},\"VsockStdioRelaySettings\":{\"StdIn\":1073741952,\"StdOut\":1073741953,\"StdErr\":1073741954}}}'\n
"
time="2017-09-08T21:29:01Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741952)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":-2147467259,\"ActivityId\":\"0000000
0-0000-0000-0000-000000000000\",\"ErrorRecords\":[{\"Result\":-2147467259,\"Message\":\"failed creating stdin Connection: failed connecting th
e VsockConnection: failed connect() to 00000002.40000080: connection timed out\",\"StackTrace\":\"\\ngithub.com/Microsoft/opengcs/service/gcs/
transport.(*VsockTransport).Dial\\n\\t/mnt/g/gowork/src/github.com/Microsoft/opengcs/service/gcs/transport/vsock.go:27\\ngithub.com/Microsoft/
opengcs/service/gcs/bridge.connectStdio\\n\\t/mnt/g/gowork/src/github.com/Microsoft/opengcs/service/gcs/bridge/connection.go:21\\ngithub.com/M
icrosoft/opengcs/service/gcs/bridge.(*Bridge).execProcess\\n\\t/mnt/g/gowork/src/github.com/Microsoft/opengcs/service/gcs/bridge/bridge.go:382
\\ngithub.com/Microsoft/opengcs/service/gcs/bridge.(*Bridge).(github.com/Microsoft/opengcs/service/gcs/bridge.execProcess)-fm\\n\\t/mnt/g/gowo
rk/src/github.com/Microsoft/opengcs/service/gcs/bridge/bridge.go:199\\ngithub.com/Microsoft/opengcs/service/gcs/bridge.HandlerFunc.ServeMsg\\n
\\t/mnt/g/gowork/src/github.com/Microsoft/opengcs/service/gcs/bridge/bridge.go:45\\ngithub.com/Microsoft/opengcs/service/gcs/bridge.(*Mux).Ser
veMsg\\n\\t/mnt/g/gowork/src/github.com/Microsoft/opengcs/service/gcs/bridge/bridge.go:107\\ngithub.com/Microsoft/opengcs/service/gcs/bridge.(
*Bridge).ListenAndServe.func2.1\\n\\t/mnt/g/gowork/src/github.com/Microsoft/opengcs/service/gcs/bridge/bridge.go:262\\nruntime.goexit\\n\\t/us
r/local/go/src/runtime/asm_amd64.s:2197\",\"ModuleName\":\"gcs\",\"FileName\":\"vsock.go\",\"Line\":27,\"FunctionName\":\"(*VsockTransport).Di
al\"}]}' to HCS\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"Request\":{\"ResourceType\":\"MappedVirtualD
isk\",\"RequestType\":\"Remove\",\"Settings\":{\"Lun\":3,\"CreateInUtilityVM\":true,\"AttachOnly\":true}}}'\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\"}' to HCS\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"Settings\":{\"ProcessParameters\":\"{\\\"Com
mandLine\\\":\\\"sh -c \\\\\\\"echo -e 'DEBUG COMMAND: ls -l /tmp\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /tmp;echo -e '\\\\\\\
\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /tmp/gcs.log\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';cat /tmp/gcs.log;echo -
e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /tmp/gcs;
echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs/*\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /
tmp/gcs/*;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /tmp/gcs/*/config.json\\\\\\\\\\\\\\\\n--------------\\\\\\
\\\\\\\\\\n';cat /tmp/gcs/*/config.json;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -lR /var/run/gcsrunc\\\\\\\\\\
\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -lR /var/run/gcsrunc;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /var/
run/gcsrunc/log.log\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';cat /var/run/gcsrunc/log.log;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n'
;echo -e 'DEBUG COMMAND: ps -ef\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ps -ef;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';\\\\\\\"\
\\",\\\"ConsoleSize\\\":[0,0],\\\"CreateInUtilityVm\\\":true,\\\"CreateStdErrPipe\\\":true,\\\"CreateStdInPipe\\\":true,\\\"CreateStdOutPipe\\
\":true,\\\"Environment\\\":{\\\"PATH\\\":\\\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\\\"},\\\"StdErrPipe\\\":\\\"\\\\\\
\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-138\\\",\\\"StdInPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-136\\\",\\\"StdOutPipe\\\":\\\"\
\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-137\\\",\\\"WorkingDirectory\\\":\\\"/bin\\\"}\",\"StdioRelaySettings\":{\"StdIn\":\"00000000-0000-0
000-0000-000000000000\",\"StdOut\":\"00000000-0000-0000-0000-000000000000\",\"StdErr\":\"00000000-0000-0000-0000-000000000000\"},\"VsockStdioR
elaySettings\":{\"StdIn\":1073741955,\"StdOut\":1073741956,\"StdErr\":1073741957}}}'\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741955)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741955)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741956)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741956)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741957)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741957)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"ProcessId\":418}' to HCS\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"ProcessId\":418,\"TimeoutInMs\":4294967295}'
\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() external process 418 exited with exit status 0"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"ExitCode\":0}' to HCS\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"Settings\":{\"ProcessParameters\":\"{\\\"Com
mandLine\\\":\\\"sh -c \\\\\\\"echo -e 'DEBUG COMMAND: ls -l /tmp\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /tmp;echo -e '\\\\\\\
\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /tmp/gcs.log\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';cat /tmp/gcs.log;echo -
e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /tmp/gcs;
echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs/*\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -l /
tmp/gcs/*;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /tmp/gcs/*/config.json\\\\\\\\\\\\\\\\n--------------\\\\\\
\\\\\\\\\\n';cat /tmp/gcs/*/config.json;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: ls -lR /var/run/gcsrunc\\\\\\\\\\
\\\\\\n--------------\\\\\\\\\\\\\\\\n';ls -lR /var/run/gcsrunc;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';echo -e 'DEBUG COMMAND: cat /var/
run/gcsrunc/log.log\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';cat /var/run/gcsrunc/log.log;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n'
;echo -e 'DEBUG COMMAND: ps -ef\\\\\\\\\\\\\\\\n--------------\\\\\\\\\\\\\\\\n';ps -ef;echo -e '\\\\\\\\\\\\\\\\n\\\\\\\\\\\\\\\\n';\\\\\\\"\
\\",\\\"ConsoleSize\\\":[0,0],\\\"CreateInUtilityVm\\\":true,\\\"CreateStdErrPipe\\\":true,\\\"CreateStdInPipe\\\":true,\\\"CreateStdOutPipe\\
\":true,\\\"Environment\\\":{\\\"PATH\\\":\\\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:\\\"},\\\"StdErrPipe\\\":\\\"\\\\\\
\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-141\\\",\\\"StdInPipe\\\":\\\"\\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-139\\\",\\\"StdOutPipe\\\":\\\"\
\\\\\\\\\\\\\\\.\\\\\\\\pipe\\\\\\\\cexec-140\\\",\\\"WorkingDirectory\\\":\\\"/bin\\\"}\",\"StdioRelaySettings\":{\"StdIn\":\"00000000-0000-0
000-0000-000000000000\",\"StdOut\":\"00000000-0000-0000-0000-000000000000\",\"StdErr\":\"00000000-0000-0000-0000-000000000000\"},\"VsockStdioR
elaySettings\":{\"StdIn\":1073741955,\"StdOut\":1073741956,\"StdErr\":1073741957}}}'\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741955)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741955)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741956)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741956)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Dial port (1073741957)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() vsock Connect port (1073741957)"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: response sent: '{\"Result\":0,\"ActivityId\":\"00000000-0000-000
0-0000-000000000000\",\"ProcessId\":428}' to HCS\n"
time="2017-09-08T21:29:03Z" level=info msg="/mnt/g/gowork/src/github.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus/entry.go:97 githu
b.com/Microsoft/opengcs/vendor/github.com/sirupsen/logrus.Entry.log() bridge: read message '{\"ContainerId\":\"0c671427f420bb4d664c8cd79b20ece
902b8c5b77f5992bb279df640000a986d_svm\",\"ActivityId\":\"00000000-0000-0000-0000-000000000000\",\"ProcessId\":428,\"TimeoutInMs\":4294967295}'
\n"



DEBUG COMMAND: ls -l /tmp/gcs
--------------

total 0
drwxr-xr-x    4 0        0               80 Sep  8 21:29 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm



DEBUG COMMAND: ls -l /tmp/gcs/*
--------------

total 0
drwxr-xr-x    1 0        0               40 Sep  8 21:29 rootfs
drwxr-xr-x    4 0        0               80 Sep  8 21:29 scratch



DEBUG COMMAND: cat /tmp/gcs/*/config.json
--------------




DEBUG COMMAND: ls -lR /var/run/gcsrunc
--------------

/var/run/gcsrunc:
total 0



DEBUG COMMAND: cat /var/run/gcsrunc/log.log
--------------




DEBUG COMMAND: ps -ef
--------------

PID   USER     TIME   COMMAND
    1 0          0:00 {init} /bin/sh /init
    2 0          0:00 [kthreadd]
    3 0          0:00 [kworker/0:0]
    4 0          0:00 [kworker/0:0H]
    5 0          0:00 [kworker/u128:0]
    6 0          0:00 [mm_percpu_wq]
    7 0          0:00 [ksoftirqd/0]
    8 0          0:00 [rcu_sched]
    9 0          0:00 [rcu_bh]
   10 0          0:00 [migration/0]
   11 0          0:00 [watchdog/0]
   12 0          0:00 [cpuhp/0]
   13 0          0:00 [cpuhp/1]
   14 0          0:00 [watchdog/1]
   15 0          0:00 [migration/1]
   16 0          0:00 [ksoftirqd/1]
   17 0          0:00 [kworker/1:0]
   18 0          0:00 [kworker/1:0H]
   19 0          0:00 [kdevtmpfs]
   20 0          0:00 [netns]
   21 0          0:00 [kworker/0:1]
   22 0          0:00 [khungtaskd]
   23 0          0:00 [oom_reaper]
   24 0          0:00 [writeback]
   25 0          0:00 [kcompactd0]
   26 0          0:00 [ksmd]
   27 0          0:00 [khugepaged]
   28 0          0:00 [crypto]
   29 0          0:00 [kintegrityd]
   30 0          0:00 [bioset]
   31 0          0:00 [kblockd]
   32 0          0:00 [hv_vmbus_con]
   33 0          0:00 [hv_vmbus_rsd]
   34 0          0:00 [devfreq_wq]
   39 0          0:00 [kworker/1:1]
  130 0          0:00 [kswapd0]
  131 0          0:00 [bioset]
  132 0          0:00 [cifsiod]
  133 0          0:00 [bioset]
  134 0          0:00 [xfsalloc]
  135 0          0:00 [xfs_mru_cache]
  205 0          0:00 [kthrotld]
  206 0          0:00 [nfit]
  207 0          0:00 [kworker/u128:1]
  208 0          0:00 [bioset]
  209 0          0:00 [bioset]
  210 0          0:00 [bioset]
  211 0          0:00 [bioset]
  212 0          0:00 [bioset]
  213 0          0:00 [bioset]
  214 0          0:00 [bioset]
  215 0          0:00 [bioset]
  216 0          0:00 [bioset]
  217 0          0:00 [bioset]
  218 0          0:00 [bioset]
  219 0          0:00 [bioset]
  220 0          0:00 [bioset]
  221 0          0:00 [bioset]
  222 0          0:00 [bioset]
  223 0          0:00 [bioset]
  224 0          0:00 [bioset]
  225 0          0:00 [bioset]
  226 0          0:00 [bioset]
  227 0          0:00 [bioset]
  228 0          0:00 [bioset]
  229 0          0:00 [bioset]
  230 0          0:00 [bioset]
  231 0          0:00 [bioset]
  232 0          0:00 [knbd-recv]
  233 0          0:00 [bioset]
  234 0          0:00 [bioset]
  235 0          0:00 [bioset]
  236 0          0:00 [bioset]
  237 0          0:00 [bioset]
  238 0          0:00 [bioset]
  239 0          0:00 [bioset]
  240 0          0:00 [bioset]
  241 0          0:00 [bioset]
  242 0          0:00 [bioset]
  243 0          0:00 [bioset]
  244 0          0:00 [bioset]
  245 0          0:00 [bioset]
  246 0          0:00 [bioset]
  247 0          0:00 [bioset]
  248 0          0:00 [bioset]
  249 0          0:00 [scsi_eh_0]
  250 0          0:00 [scsi_tmf_0]
  253 0          0:00 [bioset]
  284 0          0:00 [nvme]
  285 0          0:00 [dm_bufio_cache]
  286 0          0:00 [ipv6_addrconf]
  332 0          0:00 ./gcs -loglevel=debug -logfile=/tmp/gcs.log
  336 0          0:00 sh
  337 0          0:00 [ext4-rsv-conver]
  338 0          0:00 [kworker/0:1H]
  339 0          0:00 [ext4lazyinit]
  343 0          0:00 [kworker/0:2]
  363 0          0:00 [kworker/0:3]
  428 0          0:00 sh -c echo -e 'DEBUG COMMAND: ls -l /tmp\n--------------\n';ls -l /tmp;echo -e '\n\n';echo -e 'DEBUG COMMAND: cat /tmp/g
cs.log\n--------------\n';cat /tmp/gcs.log;echo -e '\n\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs\n--------------\n';ls -l /tmp/gcs;echo -e '\n
\n';echo -e 'DEBUG COMMAND: ls -l /tmp/gcs/*\n--------------\n';ls -l /tmp/gcs/*;echo -e '\n\n';echo -e 'DEBUG COMMAND: cat /tmp/gcs/*/config.
json\n--------------\n';cat /tmp/gcs/*/config.json;echo -e '\n\n';echo -e 'DEBUG COMMAND: ls -lR /var/run/gcsrunc\n--------------\n';ls -lR /v
ar/run/gcsrunc;echo -e '\n\n';echo -e 'DEBUG COMMAND: cat /var/run/gcsrunc/log.log\n--------------\n';cat /var/run/gcsrunc/log.log;echo -e '\n
\n';echo -e 'DEBUG COMMAND: ps -ef\n--------------\n';ps -ef;echo -e '\n\n';
  436 0          0:00 ps -ef
End GCS Debugging

DEBU[2017-09-08T14:29:04.590914400-07:00] HCSShim::Process::Kill processid=428
DEBU[2017-09-08T14:29:04.590914400-07:00] Result: {"Error":-2147023728,"ErrorMessage":"Element not found."}
DEBU[2017-09-08T14:29:04.590914400-07:00] HCSShim::Process::Close processid=428
DEBU[2017-09-08T14:29:04.590914400-07:00] HCSShim::Process::Close succeeded processid=428
DEBU[2017-09-08T14:29:04.591921600-07:00] lcowdriver: createreadwrite: id 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d: re
leasing svm for sandbox creation
DEBU[2017-09-08T14:29:04.593922600-07:00] lcowdriver: createreadwrite: id 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d: re
leasing cachedSandboxMutex for creation
DEBU[2017-09-08T14:29:04.593922600-07:00] lcowdriver: getservicevm:locking serviceVmsMutex
DEBU[2017-09-08T14:29:04.594925800-07:00] lcowdriver: getservicevm: removing 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d
from map
DEBU[2017-09-08T14:29:04.594925800-07:00] lcowdriver: getservicevm:releasing serviceVmsMutex
DEBU[2017-09-08T14:29:04.594925800-07:00] lcowdriver: terminateservicevm: 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d (cr
eatereadwrite) - calling terminate
DEBU[2017-09-08T14:29:04.594925800-07:00] HCSShim::Container::Terminate id=0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_sv
m
DEBU[2017-09-08T14:29:04.644929800-07:00] lcowdriver: terminateservicevm: 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d (cr
eatereadwrite) - deleting scratch c:\lcow\lcow\scratch\0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d.vhdx
DEBU[2017-09-08T14:29:04.645931200-07:00] FIXME: Got an API for which error does not match any expected type!!!: failed to `ls /sys/bus/scsi/d
evices/0:0:0:3/block` following hot-add c:\lcow\lcow\0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d\sandbox.vhdx to utility
VM: failed to create process (&{Options:{KirdPath:C:\Program Files\Linux Containers KernelFile:bootx64.efi InitrdFile:initrd.img Vhdx:C:\Progr
am Files\Linux Containers\uvm.vhdx TimeoutSeconds:0 BootParameters:} Name:0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm
 RequestedMode:3 ActualMode:2 UvmTimeoutSeconds:300 Uvm:0xc0428da980 MappedVirtualDisks:[{HostPath:c:\lcow\lcow\scratch\0c671427f420bb4d664c8c
d79b20ece902b8c5b77f5992bb279df640000a986d.vhdx ContainerPath:/tmp/scratch CreateInUtilityVM:true ReadOnly:false Cache: AttachOnly:false}]}) i
n utility VM: container 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm encountered an error during CreateProcess: failur
e in a Windows system call: Unspecified error (0x80004005) extra info: {"CommandLine":"ls /sys/bus/scsi/devices/0:0:0:3/block","WorkingDirecto
ry":"/bin","Environment":{"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"},"CreateStdInPipe":true,"CreateStdOutPipe":tr
ue,"CreateStdErrPipe":true,"ConsoleSize":[0,0],"CreateInUtilityVm":true}  error_type="*errors.errorString" module=api
ERRO[2017-09-08T14:29:04.646925300-07:00] Handler for POST /v1.32/containers/create returned error: failed to `ls /sys/bus/scsi/devices/0:0:0:
3/block` following hot-add c:\lcow\lcow\0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d\sandbox.vhdx to utility VM: failed to
 create process (&{Options:{KirdPath:C:\Program Files\Linux Containers KernelFile:bootx64.efi InitrdFile:initrd.img Vhdx:C:\Program Files\Linu
x Containers\uvm.vhdx TimeoutSeconds:0 BootParameters:} Name:0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm RequestedMod
e:3 ActualMode:2 UvmTimeoutSeconds:300 Uvm:0xc0428da980 MappedVirtualDisks:[{HostPath:c:\lcow\lcow\scratch\0c671427f420bb4d664c8cd79b20ece902b
8c5b77f5992bb279df640000a986d.vhdx ContainerPath:/tmp/scratch CreateInUtilityVM:true ReadOnly:false Cache: AttachOnly:false}]}) in utility VM:
 container 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm encountered an error during CreateProcess: failure in a Window
s system call: Unspecified error (0x80004005) extra info: {"CommandLine":"ls /sys/bus/scsi/devices/0:0:0:3/block","WorkingDirectory":"/bin","E
nvironment":{"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"},"CreateStdInPipe":true,"CreateStdOutPipe":true,"CreateStd
ErrPipe":true,"ConsoleSize":[0,0],"CreateInUtilityVm":true}
DEBU[2017-09-08T14:29:04.646925300-07:00] FIXME: Got an API for which error does not match any expected type!!!: failed to `ls /sys/bus/scsi/d
evices/0:0:0:3/block` following hot-add c:\lcow\lcow\0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d\sandbox.vhdx to utility
VM: failed to create process (&{Options:{KirdPath:C:\Program Files\Linux Containers KernelFile:bootx64.efi InitrdFile:initrd.img Vhdx:C:\Progr
am Files\Linux Containers\uvm.vhdx TimeoutSeconds:0 BootParameters:} Name:0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm
 RequestedMode:3 ActualMode:2 UvmTimeoutSeconds:300 Uvm:0xc0428da980 MappedVirtualDisks:[{HostPath:c:\lcow\lcow\scratch\0c671427f420bb4d664c8c
d79b20ece902b8c5b77f5992bb279df640000a986d.vhdx ContainerPath:/tmp/scratch CreateInUtilityVM:true ReadOnly:false Cache: AttachOnly:false}]}) i
n utility VM: container 0c671427f420bb4d664c8cd79b20ece902b8c5b77f5992bb279df640000a986d_svm encountered an error during CreateProcess: failur
e in a Windows system call: Unspecified error (0x80004005) extra info: {"CommandLine":"ls /sys/bus/scsi/devices/0:0:0:3/block","WorkingDirecto
ry":"/bin","Environment":{"PATH":"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:"},"CreateStdInPipe":true,"CreateStdOutPipe":tr
ue,"CreateStdErrPipe":true,"ConsoleSize":[0,0],"CreateInUtilityVm":true}  error_type="*errors.errorString" module=api

```




