### PR TITLE
Improve the vsock timeout handling

### DIFF
--- a/vendor/github.com/linuxkit/virtsock/LICENSE
+++ b/vendor/github.com/linuxkit/virtsock/LICENSE
@@ -1,3 +1,6 @@
+Unless explicitly stated at the top of the file, this code is covered
+by the following license:
+
 Copyright 2016-2017 The authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,61 +14,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-
-
-Some of the code in ./go/hvsock.go, ./go/hvsock_windows.go, and
-zsyscall_windows.go is covered by the following licenses:
-==============================================================================
-
-The MIT License (MIT)
-
-Copyright (c) 2015 Microsoft
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-and
-===
-
-Copyright (c) 2012 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/linuxkit/virtsock/pkg/vsock/hyperkit_darwin.go
+++ b/vendor/github.com/linuxkit/virtsock/pkg/vsock/hyperkit_darwin.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -43,10 +45,10 @@ func SocketMode(socketMode string) {
 func Dial(cid, port uint32) (Conn, error) {
 	c, err := net.DialUnix("unix", nil, &net.UnixAddr{connectPath, "unix"})
 	if err != nil {
-		return c, err
+		return c, errors.Wrapf(err, "failed to dial on %s", connectPath)
 	}
 	if _, err := fmt.Fprintf(c, "%08x.%08x\n", cid, port); err != nil {
-		return c, fmt.Errorf("Failed to write dest (%08x.%08x) to %s", cid, port, connectPath)
+		return c, errors.Wrapf(err, "Failed to write dest (%08x.%08x) to %s", cid, port, connectPath)
 	}
 	return c, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -81,10 +81,10 @@
 			"revisionTime": "2017-01-27T09:51:30Z"
 		},
 		{
-			"checksumSHA1": "u0yZ272VVX6SV4jTRsfGubqzCtU=",
+			"checksumSHA1": "C+iol054pXHMVmUhwspOYJLMOD8=",
 			"path": "github.com/linuxkit/virtsock/pkg/vsock",
-			"revision": "06e97e8056a494135d7d9fa6b25b7e592508cee0",
-			"revisionTime": "2017-07-10T20:42:22Z"
+			"revision": "cce5df4cc3fbd5966290ae44f43b407205d4a2e4",
+			"revisionTime": "2017-09-14T10:10:08Z"
 		},
 		{
 			"checksumSHA1": "3yckDt/xIreJZ/spvI+MvHOCmcY=",


### PR DESCRIPTION
A new version of `pkg/vsock` (vendored in this PR) improves error handling by wrapping the original error in any error it returns. We then use this to inspect the error returned by `Dial()` and only retry if it is `ETIMEDOUT`. On other errors we return immediately to not mask the error.

I've tested this with the intermittent failures on pull (#135) and the [PR for improved error handling](https://github.com/moby/moby/pull/34846) and I indeed see occasional:
```
[...]
 vsock Dial port (1073741952)"
 vsock Connect port (1073741952) timed out, re-trying"
 vsock Connect port (1073741952)"
 vsock Dial port (1073741953)"
[...]
```
for the `mkfs` and `ls` processes but they now succeed as the retry works

resolves #135
wip #124
 