### PR TITLE
Fixes potential delete on unmounts failure

### DIFF
--- a/service/gcs/core/gcs/cleanup.go
+++ b/service/gcs/core/gcs/cleanup.go
@@ -47,11 +47,18 @@ func (c *gcsCore) cleanupContainer(containerEntry *containerCacheEntry) error {
 			errToReturn = err
 		}
 	}
-	if err := c.destroyContainerStorage(containerEntry.ID); err != nil {
-		logrus.Warn(err)
-		if errToReturn == nil {
-			errToReturn = err
+
+	// We only do cleanup if unmounting succeeds.
+	if errToReturn == nil {
+		if err := c.destroyContainerStorage(containerEntry.ID); err != nil {
+			logrus.Warn(err)
+			if errToReturn == nil {
+				errToReturn = err
+			}
 		}
+	} else {
+		logrus.Warnf("Failed to unmount storage for container (%s). Will not delete!", containerEntry.ID)
+		logrus.Warn(errToReturn)
 	}
 
 	return errToReturn


### PR DESCRIPTION
Will only destroy the container storage in the UVM if all mounts are successfully unmounted. Without this we have no way of knowing if it safe to delete the files or if this could have an affect on the host files.

Resolves: #131

@jhowardmsft - FYI