### PR TITLE
Added new hyperv vsock patches for addressing connection close racing…

### DIFF
--- a/kernel/patches-4.11.x/README.md
+++ b/kernel/patches-4.11.x/README.md
@@ -44,6 +44,9 @@ git cherry-pick -x 531389d1dc73e2be3ee5dbf2091b6f5e74d9764c
 git cherry-pick -x c49aced6328557e6c1f5cf6f58e1fae96fb58fa0
 git cherry-pick -x 651dae7de6c6f066c08845ec7335bfb231d5eabe
 git cherry-pick -x e37da6e7a52ea60825ca676e0c59fe5e4ecd89d6
+git cherry-pick -x c15d7f606f813b8d1f1ce02979929fd875da228b
+git cherry-pick -x b6ffb4393fb266711b37ed056487665d8650f31a
+
 ```
 
 Another way to get the patches is to download them from the following list and
@@ -67,6 +70,8 @@ apply them in the same order:
 16. https://github.com/dcui/linux/commit/c49aced6328557e6c1f5cf6f58e1fae96fb58fa0.patch
 17. https://github.com/dcui/linux/commit/651dae7de6c6f066c08845ec7335bfb231d5eabe.patch
 18. https://github.com/dcui/linux/commit/e37da6e7a52ea60825ca676e0c59fe5e4ecd89d6.patch
+19. https://github.com/dcui/linux/commit/c15d7f606f813b8d1f1ce02979929fd875da228b.patch
+20. https://github.com/dcui/linux/commit/b6ffb4393fb266711b37ed056487665d8650f31a.patch
 
 
 ## 3. Patch for "ext4: fix fault handling when mounted with -o dax,ro"

--- a/kernel/patches-4.12.x/README.md
+++ b/kernel/patches-4.12.x/README.md
@@ -44,6 +44,8 @@ git cherry-pick -x 7592de58cbf8d199d721503385c20a02743425a9
 git cherry-pick -x 02d07a9dcdb042f33248fd3aeb1e5c2eca6d3d49
 git cherry-pick -x f315dfcf9c3b4b32f43a21664762cbacd8f05d6a
 git cherry-pick -x d6f7158fdbac10f9935a506451e3d54d2d50a7c7
+git cherry-pick -x c15d7f606f813b8d1f1ce02979929fd875da228b
+git cherry-pick -x b6ffb4393fb266711b37ed056487665d8650f31a
 
 ```
 
@@ -67,7 +69,8 @@ apply them in the same order:
 15. https://github.com/dcui/linux/commit/02d07a9dcdb042f33248fd3aeb1e5c2eca6d3d49.patch
 16. https://github.com/dcui/linux/commit/f315dfcf9c3b4b32f43a21664762cbacd8f05d6a.patch
 17. https://github.com/dcui/linux/commit/d6f7158fdbac10f9935a506451e3d54d2d50a7c7.patch
-
+18. https://github.com/dcui/linux/commit/c15d7f606f813b8d1f1ce02979929fd875da228b.patch
+19. https://github.com/dcui/linux/commit/b6ffb4393fb266711b37ed056487665d8650f31a.patch
 
 ## 3. Patch for "ext4: fix fault handling when mounted with -o dax,ro"
 


### PR DESCRIPTION
… condition issue

This new patch addressed the `vmbus_on_event()` kernel crash" that rneugeba reported last week.