### PR TITLE
Fixing issues with process exit

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -347,7 +347,7 @@ func (b *Bridge) createContainer(w ResponseWriter, r *Request) {
 
 	exitCodeFn, err := b.coreint.WaitContainer(id)
 	if err != nil {
-		w.Error(request.ActivityID, err)
+		logrus.Error(err)
 	}
 
 	go func() {

--- a/service/gcs/core/core.go
+++ b/service/gcs/core/core.go
@@ -21,6 +21,6 @@ type Core interface {
 	RunExternalProcess(info prot.ProcessParameters, stdioSet *stdio.ConnectionSet) (pid int, err error)
 	ModifySettings(id string, request prot.ResourceModificationRequestResponse) error
 	ResizeConsole(pid int, height, width uint16) error
-	WaitContainer(id string) (int, error)
-	WaitProcess(pid int) (int, error)
+	WaitContainer(id string) (func() int, error)
+	WaitProcess(pid int) (func() int, error)
 }

--- a/service/gcs/core/core.go
+++ b/service/gcs/core/core.go
@@ -22,5 +22,5 @@ type Core interface {
 	ModifySettings(id string, request prot.ResourceModificationRequestResponse) error
 	ResizeConsole(pid int, height, width uint16) error
 	WaitContainer(id string) (func() int, error)
-	WaitProcess(pid int) (func() int, error)
+	WaitProcess(pid int) (chan int, chan bool, error)
 }

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -1076,13 +1076,15 @@ var _ = Describe("GCS", func() {
 			Describe("calling wait process", func() {
 				var (
 					pid      int
-					exitCode int = -1
+					exitCode int
 				)
 				JustBeforeEach(func() {
-					var exitCodeFn func() int
-					exitCodeFn, err = coreint.WaitProcess(pid)
+					var exitCodeChan chan int
+					var doneChan chan bool
+					exitCodeChan, doneChan, err = coreint.WaitProcess(pid)
 					if err == nil {
-						exitCode = exitCodeFn()
+						exitCode = <-exitCodeChan
+						doneChan <- true
 					}
 				})
 				Context("process does not exist", func() {

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -1049,10 +1049,14 @@ var _ = Describe("GCS", func() {
 			})
 			Describe("calling wait container", func() {
 				var (
-					exitCode int
+					exitCode int = -1
 				)
 				JustBeforeEach(func() {
-					exitCode, err = coreint.WaitContainer(containerID)
+					var exitCodeFn func() int
+					exitCodeFn, err = coreint.WaitContainer(containerID)
+					if err == nil {
+						exitCode = exitCodeFn()
+					}
 				})
 				Context("container does not exist", func() {
 					It("should produce errors", func() {
@@ -1072,10 +1076,14 @@ var _ = Describe("GCS", func() {
 			Describe("calling wait process", func() {
 				var (
 					pid      int
-					exitCode int
+					exitCode int = -1
 				)
 				JustBeforeEach(func() {
-					exitCode, err = coreint.WaitProcess(pid)
+					var exitCodeFn func() int
+					exitCodeFn, err = coreint.WaitProcess(pid)
+					if err == nil {
+						exitCode = exitCodeFn()
+					}
 				})
 				Context("process does not exist", func() {
 					It("should produce an error", func() {

--- a/service/gcs/core/mockcore/mockcore.go
+++ b/service/gcs/core/mockcore/mockcore.go
@@ -193,18 +193,18 @@ func (c *MockCore) ResizeConsole(pid int, height, width uint16) error {
 }
 
 // WaitContainer captures its arguments and returns a nil error.
-func (c *MockCore) WaitContainer(id string) (int, error) {
+func (c *MockCore) WaitContainer(id string) (func() int, error) {
 	c.LastWaitContainer = WaitContainerCall{
 		ID: id,
 	}
 	c.WaitContainerWg.Done()
-	return -1, c.behaviorResult()
+	return func() { return -1 }, c.behaviorResult()
 }
 
 // WaitProcess captures its arguments and returns a nil error.
-func (c *MockCore) WaitProcess(pid int) (int, error) {
+func (c *MockCore) WaitProcess(pid int) (func() int, error) {
 	c.LastWaitProcess = WaitProcessCall{
 		Pid: pid,
 	}
-	return -1, c.behaviorResult()
+	return func() { return -1 }, c.behaviorResult()
 }

--- a/service/gcs/core/mockcore/mockcore.go
+++ b/service/gcs/core/mockcore/mockcore.go
@@ -198,13 +198,13 @@ func (c *MockCore) WaitContainer(id string) (func() int, error) {
 		ID: id,
 	}
 	c.WaitContainerWg.Done()
-	return func() { return -1 }, c.behaviorResult()
+	return func() int { return -1 }, c.behaviorResult()
 }
 
 // WaitProcess captures its arguments and returns a nil error.
-func (c *MockCore) WaitProcess(pid int) (func() int, error) {
+func (c *MockCore) WaitProcess(pid int) (chan int, chan bool, error) {
 	c.LastWaitProcess = WaitProcessCall{
 		Pid: pid,
 	}
-	return func() { return -1 }, c.behaviorResult()
+	return nil, nil, c.behaviorResult()
 }

--- a/service/gcs/gcserr/errors.go
+++ b/service/gcs/gcserr/errors.go
@@ -23,6 +23,8 @@ const (
 	HrFail = Hresult(-2147467259) // 0x80004005
 	// HrAccessDenied is the HRESULT for access denied to a resource.
 	HrAccessDenied = Hresult(-2147024891) // 0x80070005
+	// HvVmcomputeTimeout is the HRESULT for operations that timed out.
+	HvVmcomputeTimeout = Hresult(-1070137079) // 0xC0370109
 	// HrVmcomputeInvalidJSON is the HRESULT for failing to unmarshal a json
 	// string.
 	HrVmcomputeInvalidJSON = Hresult(-1070137075) // 0xC037010D


### PR DESCRIPTION
Resolves: #153 - Init process exit codes are not always returning because the container exited notification returns before the WaitProcess call comes in causing the HCS to teardown the container.
Resolves: #126 - WaitProcess should honor the timeout associated with the call and return the proper error response on timeout.