### PR TITLE
Unknown messages should return E_VMCOMPUTE_UNKNOWN_MESSAGE

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -26,16 +26,16 @@ var capabilities = prot.GcsCapabilities{
 	SendInitialCreateMessage: false,
 }
 
-// NotSupported represents the default handler logic for an unmatched
-// request type sent from the bridge.
-func NotSupported(w ResponseWriter, r *Request) {
-	w.Error("", gcserr.WrapHresult(errors.Errorf("bridge: function not supported, header type: 0x%x", r.Header.Type), gcserr.HrNotImpl))
+// UnknownMessage represents the default handler logic for an unmatched request
+// type sent from the bridge.
+func UnknownMessage(w ResponseWriter, r *Request) {
+	w.Error("", gcserr.WrapHresult(errors.Errorf("bridge: function not supported, header type: 0x%x", r.Header.Type), gcserr.HrVmcomputeUnknownMessage))
 }
 
-// NotSupportedHandler creates a default HandlerFunc out of
-// the NotSupported handler logic.
-func NotSupportedHandler() Handler {
-	return HandlerFunc(NotSupported)
+// UnknownMessageHandler creates a default HandlerFunc out of the
+// UnknownMessage handler logic.
+func UnknownMessageHandler() Handler {
+	return HandlerFunc(UnknownMessage)
 }
 
 // Handler responds to a bridge request.
@@ -104,12 +104,12 @@ func (mux *Mux) Handler(r *Request) Handler {
 	var m map[prot.ProtocolVersion]Handler
 	var ok bool
 	if m, ok = mux.m[r.Header.Type]; !ok {
-		return NotSupportedHandler()
+		return UnknownMessageHandler()
 	}
 
 	var h Handler
 	if h, ok = m[r.Version]; !ok {
-		return NotSupportedHandler()
+		return UnknownMessageHandler()
 	}
 
 	return h

--- a/service/gcs/bridge/bridge_unit_test.go
+++ b/service/gcs/bridge/bridge_unit_test.go
@@ -155,14 +155,14 @@ func Test_Bridge_Mux_Handler_NilRequest_Panic(t *testing.T) {
 	m.Handler(nil)
 }
 
-func verifyResponseIsDeaultHandler(t *testing.T, i interface{}) {
+func verifyResponseIsDefaultHandler(t *testing.T, i interface{}) {
 	if i == nil {
 		t.Error("The response is nil")
 		return
 	}
 
 	base := i.(*prot.MessageResponseBase)
-	if base.Result != int32(gcserr.HrNotImpl) {
+	if base.Result != int32(gcserr.HrVmcomputeUnknownMessage) {
 		t.Error("The default handler did not set a -1 error result.")
 	}
 	if len(base.ErrorRecords) != 1 {
@@ -194,7 +194,7 @@ func Test_Bridge_Mux_Handler_NotAdded_Default(t *testing.T) {
 
 	select {
 	case resp := <-respChan:
-		verifyResponseIsDeaultHandler(t, resp.response)
+		verifyResponseIsDefaultHandler(t, resp.response)
 	default:
 		t.Error("The deafult handler returned no writes.")
 	}
@@ -228,7 +228,7 @@ func Test_Bridge_Mux_Handler_Added_NotMatched(t *testing.T) {
 
 	select {
 	case resp := <-respChan:
-		verifyResponseIsDeaultHandler(t, resp.response)
+		verifyResponseIsDefaultHandler(t, resp.response)
 	default:
 		t.Error("The deafult handler returned no writes.")
 	}
@@ -285,7 +285,7 @@ func Test_Bridge_Mux_ServeMsg_NotAdded_Default(t *testing.T) {
 
 	select {
 	case resp := <-respChan:
-		verifyResponseIsDeaultHandler(t, resp.response)
+		verifyResponseIsDefaultHandler(t, resp.response)
 	default:
 		t.Error("The deafult handler returned no writes.")
 	}
@@ -319,7 +319,7 @@ func Test_Bridge_Mux_ServeMsg_Added_NotMatched(t *testing.T) {
 
 	select {
 	case resp := <-respChan:
-		verifyResponseIsDeaultHandler(t, resp.response)
+		verifyResponseIsDefaultHandler(t, resp.response)
 	default:
 		t.Error("The deafult handler returned no writes.")
 	}
@@ -434,7 +434,7 @@ func serverRead(conn transport.Connection) (*prot.MessageHeader, []byte, error) 
 	return header, message, nil
 }
 
-func Test_Bridge_ListenAndServe_NotSupportedHandler_Success(t *testing.T) {
+func Test_Bridge_ListenAndServe_UnknownMessageHandler_Success(t *testing.T) {
 	// Turn off logging so as not to spam output.
 	logrus.SetOutput(ioutil.Discard)
 
@@ -444,7 +444,7 @@ func Test_Bridge_ListenAndServe_NotSupportedHandler_Success(t *testing.T) {
 
 	b := &Bridge{
 		Transport: mt,
-		Handler:   NotSupportedHandler(),
+		Handler:   UnknownMessageHandler(),
 	}
 
 	go func() {
@@ -485,7 +485,7 @@ func Test_Bridge_ListenAndServe_NotSupportedHandler_Success(t *testing.T) {
 	if header.ID != prot.SequenceID(1) {
 		t.Error("Response header had wrong sequence id")
 	}
-	verifyResponseIsDeaultHandler(t, response)
+	verifyResponseIsDefaultHandler(t, response)
 }
 
 func Test_Bridge_ListenAndServe_CorrectHandler_Success(t *testing.T) {

--- a/service/gcs/gcserr/errors.go
+++ b/service/gcs/gcserr/errors.go
@@ -34,6 +34,9 @@ const (
 	// HrVmcomputeUnsupportedProtocolVersion is the HRESULT for an invalid
 	// protocol version range specified at negotiation.
 	HrVmcomputeUnsupportedProtocolVersion = Hresult(-1070137076) // 0xC037010C
+	// HrVmcomputeUnknownMessage is the HRESULT for unknown message types sent
+	// from the HCS.
+	HrVmcomputeUnknownMessage = Hresult(-1070137077) // 0xC037010B
 )
 
 type containerExistsError struct {


### PR DESCRIPTION
They used to return E_NOTIMPL, which is different from what the Windows
GCS would return.

Resolves #175
  