### PR TITLE
Basic panic logger for gcstools

### DIFF
--- a/client/process.go
+++ b/client/process.go
@@ -134,6 +134,7 @@ func (config *Config) DebugGCS() {
 		cmd += debugCommand("ls -l /tmp")
 		cmd += debugCommand("cat /tmp/gcs.log")
 		cmd += debugCommand("cat /tmp/gcs/gcs-stacks*")
+		cmd += debugCommand("cat /tmp/gcs/paniclog*")
 		cmd += debugCommand("ls -l /tmp/gcs")
 		cmd += debugCommand("ls -l /tmp/gcs/*")
 		cmd += debugCommand("cat /tmp/gcs/*/config.json")


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Writes a paniclog if one of the GCS tools crashes, and turns on client-side (docker) ability to be able to grab the logs back. Will be written as `/tmp/paniclog.<toolname>.pid`

@jterry75 As mentioned