### PR TITLE
Translate io.EOF

### DIFF
--- a/service/gcsutils/remotefs/utils.go
+++ b/service/gcsutils/remotefs/utils.go
@@ -43,6 +43,8 @@ func ExportedToError(ee *ExportedError) error {
 		return os.ErrExist
 	} else if ee.Error() == os.ErrPermission.Error() {
 		return os.ErrPermission
+	} else if ee.Error() == io.EOF.Error() {
+		return io.EOF
 	}
 	return ee
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Without this (and a matching docker fix), ReadFile will fail with the pipe is being closed during its io.Copy as it never gets the EOF when all data has been read.

@jterry75 @gupta-ak 
