### PR TITLE
Adds advanced debugging to dump data to/from UVM

### DIFF
--- a/client/init.go
+++ b/client/init.go
@@ -1,0 +1,24 @@
+// +build windows
+
+package client
+
+import (
+	"os"
+	"strconv"
+)
+
+var (
+	logDataFromUVM int64
+)
+
+func init() {
+	bytes := os.Getenv("OPENGCS_LOG_DATA_FROM_UVM")
+	if len(bytes) == 0 {
+		return
+	}
+	u, err := strconv.ParseUint(bytes, 10, 32)
+	if err != nil {
+		return
+	}
+	logDataFromUVM = int64(u)
+}


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 

As shown to you. This adds some advanced debugging where you set environment variable `OPENGCS_LOG_DATA_FROM_UVM` to the max number of bytes you want logged in data sent to/from the utility VM. It also is only dumped if logrus is in at least debug level.

With this change, you get something like this now in the docker log when enabled:

```
DEBU[2018-01-18T11:40:30.583222200-08:00] opengcs: copywithtimeout: size 0: timeout 300: (RunProcess: copy back from remotefs stat /tmp/1762bd2dd03cd34e570c8f21368491b3289e666e47ed9d2bd043b892c2995787-mount/file)
DEBU[2018-01-18T11:40:30.608245100-08:00] opengcs: copyWithTimeout
00000000  7b 22 4e 61 6d 65 56 61  72 22 3a 22 66 69 6c 65  |{"NameVar":"file|
00000010  22 2c 22 53 69 7a 65 56  61 72 22 3a 37 34 2c 22  |","SizeVar":74,"|
00000020  4d 6f 64 65 56 61 72 22  3a 34 33 38 2c 22 4d 6f  |ModeVar":438,"Mo|
00000030  64 54 69 6d 65 56 61 72  22 3a 31 35 31 36 31 33  |dTimeVar":151613|
00000040  36 32 39 32 30 30 30 30  30 30 30 30 30 2c 22 49  |6292000000000,"I|
00000050  73 44 69 72 56 61 72 22  3a 66 61 6c 73 65 7d     |sDirVar":false}|

DEBU[2018-01-18T11:40:30.608245100-08:00] opengcs: copyWithTimeout: success - copied 95 bytes (RunProcess: copy back from remotefs stat /tmp/1762bd2dd03cd34e570c8f21368491b3289e666e47ed9d2bd043b892c2995787-mount/file)
```
