### PR TITLE
Return the correct structure from GetProperties

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -201,7 +201,7 @@ func (b *Bridge) AssignHandlers(mux *Mux, gcs core.Core) {
 	mux.HandleFunc(prot.ComputeSystemShutdownForcedV1, b.killContainer)
 	mux.HandleFunc(prot.ComputeSystemShutdownGracefulV1, b.shutdownContainer)
 	mux.HandleFunc(prot.ComputeSystemSignalProcessV1, b.signalProcess)
-	mux.HandleFunc(prot.ComputeSystemGetPropertiesV1, b.listProcesses)
+	mux.HandleFunc(prot.ComputeSystemGetPropertiesV1, b.getProperties)
 	mux.HandleFunc(prot.ComputeSystemWaitForProcessV1, b.waitOnProcess)
 	mux.HandleFunc(prot.ComputeSystemResizeConsoleV1, b.resizeConsole)
 	mux.HandleFunc(prot.ComputeSystemModifySettingsV1, b.modifySettings)
@@ -456,7 +456,7 @@ func (b *Bridge) signalProcess(w ResponseWriter, r *Request) {
 	w.Write(response)
 }
 
-func (b *Bridge) listProcesses(w ResponseWriter, r *Request) {
+func (b *Bridge) getProperties(w ResponseWriter, r *Request) {
 	var request prot.ContainerGetProperties
 	if err := commonutils.UnmarshalJSONWithHresult(r.Message, &request); err != nil {
 		w.Error("", errors.Wrapf(err, "failed to unmarshal JSON for message \"%s\"", r.Message))
@@ -464,15 +464,15 @@ func (b *Bridge) listProcesses(w ResponseWriter, r *Request) {
 	}
 	id := request.ContainerID
 
-	processes, err := b.coreint.ListProcesses(id)
+	properties, err := b.coreint.GetProperties(id, request.Query)
 	if err != nil {
 		w.Error(request.ActivityID, err)
 		return
 	}
 
-	processJSON, err := json.Marshal(processes)
+	propertyJSON, err := json.Marshal(properties)
 	if err != nil {
-		w.Error(request.ActivityID, errors.Wrapf(err, "failed to marshal processes into JSON: %v", processes))
+		w.Error(request.ActivityID, errors.Wrapf(err, "failed to marshal properties into JSON: %v", properties))
 		return
 	}
 
@@ -480,7 +480,7 @@ func (b *Bridge) listProcesses(w ResponseWriter, r *Request) {
 		MessageResponseBase: &prot.MessageResponseBase{
 			ActivityID: request.ActivityID,
 		},
-		Properties: string(processJSON),
+		Properties: string(propertyJSON),
 	}
 	w.Write(response)
 }

--- a/service/gcs/bridge/bridge_handler_test.go
+++ b/service/gcs/bridge/bridge_handler_test.go
@@ -646,9 +646,68 @@ func Test_SignalProcess_CoreSucceeds_Success(t *testing.T) {
 	}
 }
 
-//
-// TODO: List Processes tests.
-//
+func Test_GetProperties_InvalidJson_Failure(t *testing.T) {
+	req, rw := setupRequestResponse(t, prot.ComputeSystemGetPropertiesV1, nil)
+
+	tb := new(Bridge)
+	tb.getProperties(rw, req)
+
+	verifyResponseJSONError(t, rw)
+	verifyActivityIDEmptyGUID(t, rw)
+}
+
+func Test_GetProperties_CoreFails_Failure(t *testing.T) {
+	r := &prot.ContainerGetProperties{
+		MessageBase: newMessageBase(),
+		Query:       "",
+	}
+
+	req, rw := setupRequestResponse(t, prot.ComputeSystemGetPropertiesV1, r)
+
+	tb := &Bridge{
+		coreint: &mockcore.MockCore{
+			Behavior: mockcore.Error,
+		},
+	}
+	tb.getProperties(rw, req)
+
+	verifyResponseError(t, rw)
+	verifyActivityID(t, r.MessageBase, rw)
+}
+
+func Test_GetProperties_CoreSucceeds_Success(t *testing.T) {
+	r := &prot.ContainerGetProperties{
+		MessageBase: newMessageBase(),
+		Query:       "{\"PropertyTypes\":[\"ProcessList\"]}",
+	}
+
+	req, rw := setupRequestResponse(t, prot.ComputeSystemGetPropertiesV1, r)
+
+	mc := &mockcore.MockCore{Behavior: mockcore.Success}
+	tb := &Bridge{coreint: mc}
+	tb.getProperties(rw, req)
+
+	verifyResponseSuccess(t, rw)
+	verifyActivityID(t, r.MessageBase, rw)
+	if mc.LastGetProperties.ID != r.ContainerID {
+		t.Fatal("last get properties did not have the same container ID")
+	}
+	response, ok := rw.response.(*prot.ContainerGetPropertiesResponse)
+	if !ok {
+		t.Fatalf("get properties returned the wrong response type: %T", rw.response)
+	}
+
+	var properties prot.Properties
+	json.Unmarshal([]byte(response.Properties), &properties)
+	numProcesses := len(properties.ProcessList)
+	if numProcesses != 1 {
+		t.Fatalf("get properties returned an incorrect number of processes: %d", numProcesses)
+	}
+	pid := properties.ProcessList[0].ProcessID
+	if pid != 101 {
+		t.Fatalf("get properties returned a process with an incorrect pid: %d", pid)
+	}
+}
 
 func Test_WaitOnProcess_InvalidJson_Failure(t *testing.T) {
 	req, rw := setupRequestResponse(t, prot.ComputeSystemWaitForProcessV1, nil)

--- a/service/gcs/core/core.go
+++ b/service/gcs/core/core.go
@@ -5,7 +5,6 @@ package core
 import (
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
-	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
 )
 
@@ -17,7 +16,7 @@ type Core interface {
 	ExecProcess(id string, info prot.ProcessParameters, stdioSet *stdio.ConnectionSet) (pid int, err error)
 	SignalContainer(id string, signal oslayer.Signal) error
 	SignalProcess(pid int, options prot.SignalProcessOptions) error
-	ListProcesses(id string) ([]runtime.ContainerProcessState, error)
+	GetProperties(id string, query string) (*prot.Properties, error)
 	RunExternalProcess(info prot.ProcessParameters, stdioSet *stdio.ConnectionSet) (pid int, err error)
 	ModifySettings(id string, request prot.ResourceModificationRequestResponse) error
 	ResizeConsole(pid int, height, width uint16) error

--- a/service/gcs/core/mockcore/mockcore.go
+++ b/service/gcs/core/mockcore/mockcore.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/Microsoft/opengcs/service/gcs/oslayer"
 	"github.com/Microsoft/opengcs/service/gcs/prot"
-	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/stdio"
 	"github.com/pkg/errors"
 )
@@ -49,9 +48,10 @@ type SignalProcessCall struct {
 	Options prot.SignalProcessOptions
 }
 
-// ListProcessesCall captures the arguments of ListProcesses.
-type ListProcessesCall struct {
-	ID string
+// GetPropertiesCall captures the arguments of GetProperties.
+type GetPropertiesCall struct {
+	ID    string
+	Query string
 }
 
 // RunExternalProcessCall captures the arguments of RunExternalProcess.
@@ -98,7 +98,7 @@ type MockCore struct {
 	LastExecProcess              ExecProcessCall
 	LastSignalContainer          SignalContainerCall
 	LastSignalProcess            SignalProcessCall
-	LastListProcesses            ListProcessesCall
+	LastGetProperties            GetPropertiesCall
 	LastRunExternalProcess       RunExternalProcessCall
 	LastModifySettings           ModifySettingsCall
 	LastResizeConsole            ResizeConsoleCall
@@ -157,17 +157,12 @@ func (c *MockCore) SignalProcess(pid int, options prot.SignalProcessOptions) err
 	return c.behaviorResult()
 }
 
-// ListProcesses captures its arguments. It then returns a process with pid
-// 101, command "sh -c testexe", CreatedByRuntime true, and IsZombie true.
-func (c *MockCore) ListProcesses(id string) ([]runtime.ContainerProcessState, error) {
-	c.LastListProcesses = ListProcessesCall{ID: id}
-	return []runtime.ContainerProcessState{
-		runtime.ContainerProcessState{
-			Pid:              101,
-			Command:          []string{"sh", "-c", "testexe"},
-			CreatedByRuntime: true,
-			IsZombie:         true,
-		},
+// GetProperties captures its arguments. It then returns a properties with a
+// process with pid 101.
+func (c *MockCore) GetProperties(id string, query string) (*prot.Properties, error) {
+	c.LastGetProperties = GetPropertiesCall{ID: id, Query: query}
+	return &prot.Properties{
+		ProcessList: []prot.ProcessDetails{prot.ProcessDetails{ProcessID: 101}},
 	}, c.behaviorResult()
 }
 

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -536,3 +536,18 @@ type ProcessParameters struct {
 type SignalProcessOptions struct {
 	Signal int32
 }
+
+// ProcessDetails represents information about a given process.
+type ProcessDetails struct {
+	ProcessID uint32 `json:"ProcessId"`
+}
+
+// PropertyQuery is a query to specify which properties are requested.
+type PropertyQuery struct {
+	PropertyTypes []PropertyType `json:",omitempty"`
+}
+
+// Properties represents the properties of a compute system.
+type Properties struct {
+	ProcessList []ProcessDetails `json:",omitempty"`
+}


### PR DESCRIPTION
Nothing in the HCS was ever sending a GetProperties message, so this
issue didn't really ever come up. We should fix it now, though.

Addresses #173 for V1 containers, but not V2 containers.