### PR TITLE
Add and rename capabilities

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -23,7 +23,9 @@ import (
 
 // The capabilities of this GCS.
 var capabilities = prot.GcsCapabilities{
-	SendInitialCreateMessage: false,
+	SendHostCreateMessage:   false,
+	SendHostStartMessage:    false,
+	HVSocketConfigOnStartup: false,
 }
 
 // UnknownMessage represents the default handler logic for an unmatched request

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -169,7 +169,17 @@ type ProtocolSupport struct {
 
 // GcsCapabilities specifies the abilities and scenarios supported by this GCS.
 type GcsCapabilities struct {
-	SendInitialCreateMessage bool
+	// True if a create message should be sent for the hosting system itself.
+	SendHostCreateMessage bool `json:",omitempty"`
+	// True if a start message should be sent for the hosting system itself. If
+	// SendHostCreateMessage is false, a start message will not be sent either.
+	SendHostStartMessage bool `json:",omitempty"`
+	// True if an HVSocket ModifySettings request should be sent immediately
+	// after the create/start messages are sent (if they're sent at all). This
+	// ModifySettings request would be to configure the local and parent
+	// Hyper-V socket addresses of the VM, and would have a RequestType of
+	// Update.
+	HVSocketConfigOnStartup bool `json:"HvSocketConfigOnStartup,omitempty"`
 }
 
 // Version is the struct sent to identify the protocol version of the HCS-GCS


### PR DESCRIPTION
This change includes renaming SendInitialCreateMessage to
SendHostCreateMessage, and adding the capabilities SendHostStartMessage
and HVSocketConfigOnStartup.