### PR TITLE
Strip debug symbols, add commit, fix alignment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,21 +17,21 @@ FROM linuxkit/runc:7b15b00b4e3507d62e3ed8d44dfe650561cd35ff AS runc
 FROM linuxkit/alpine:585174df463ba33e6c0e2050a29a0d9e942d56cb
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN \
-	# Create all the directories
-	mkdir -p /initrd/etc/apk &&  \
+    # Create all the directories
+    mkdir -p /initrd/etc/apk &&  \
     mkdir -p /initrd/bin && \
-	mkdir -p /initrd/sbin && \
-	mkdir -p /go/src/github.com/Microsoft/opengcs && \
-	\
-	# Generate base filesystem in /initrd
+    mkdir -p /initrd/sbin && \
+    mkdir -p /go/src/github.com/Microsoft/opengcs && \
+    \
+    # Generate base filesystem in /initrd
     cp -r /etc/apk/* /initrd/etc/apk/ && \
     apk add --no-cache --initdb -p /initrd alpine-baselayout busybox e2fsprogs musl && \
     rm -rf /initrd/etc/apk /initrd/lib/apk /initrd/var/cache && \
-	\
-	# Install the build packages
+    \
+    # Install the build packages
     apk add --no-cache build-base curl git go musl-dev && \
-	\
-	# Grab udhcpc_config.script
+    \
+    # Grab udhcpc_config.script
     curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /initrd/sbin/udhcpc_config.script && \
     chmod ugo+rx /initrd/sbin/udhcpc_config.script
 COPY --from=runc / /initrd/
@@ -39,5 +39,5 @@ ADD https://raw.githubusercontent.com/linuxkit/lcow/b17397d2a79e1f375e2dd3a03daf
 COPY . /go/src/github.com/Microsoft/opengcs
 RUN chmod 0755 /initrd/init && \
     cd /go/src/github.com/Microsoft/opengcs/service && make && cp -r bin /initrd && \
-	cd /initrd && find . | cpio -o --format="newc" | gzip -c > /initrd.img
-	
+    cd .. && git rev-parse HEAD > /initrd/gcs.commit && git rev-parse --abbrev-ref HEAD > /initrd/gcs.branch && \
+    cd /initrd && ls -lR && find . | cpio -o --format="newc" | gzip -c > /initrd.img

--- a/buildinitrd.ps1
+++ b/buildinitrd.ps1
@@ -5,7 +5,7 @@
     License: See https://github.com/Microsoft/opengcs/blob/master/LICENSE
 
 .Parameter Install
-   Installs the built initrd.img  
+    Installs the built initrd.img  
 
 #>
 
@@ -25,30 +25,31 @@ function New-TemporaryDirectory {
 Try {
     Write-Host -ForegroundColor Yellow "INFO: Starting at $(date)`n"
 
-	&docker build --platform=linux -t opengcs .
-	if ( $LastExitCode -ne 0 ) {
-		Throw "failed to build opengcs image"
-	}
-	
-	Write-Host -ForegroundColor Yellow "INFO: Copying initrd.img from opengcs:latest image"
-	$d=New-TemporaryDirectory
-	docker run --rm -v $d`:/out opengcs cp /initrd.img /out
-	if ( $LastExitCode -ne 0 ) {
-		Throw "failed to copy initrd.img to $d"
-	}
-	$generated = "$d`\initrd.img"
-	$size=(Get-Item $generated).Length
+    &docker build --platform=linux -t opengcs .
+    if ( $LastExitCode -ne 0 ) {
+        Throw "failed to build opengcs image"
+    }
+    
+    Write-Host -ForegroundColor Yellow "INFO: Copying initrd.img from opengcs:latest image"
+    $d=New-TemporaryDirectory
+    docker run --rm -v $d`:/out opengcs cp /initrd.img /out
+    if ( $LastExitCode -ne 0 ) {
+        Throw "failed to copy initrd.img to $d"
+    }
+    $generated = "$d`\initrd.img"
+    $size=(Get-Item $generated).Length
     Write-Host -ForegroundColor Yellow "INFO: Created $generated"
-	Write-Host -ForegroundColor Yellow "INFO: Size $size bytes"
+    Write-Host -ForegroundColor Yellow "INFO: Size $size bytes"
+    
+    if ($Install) {
+        if (Test-Path "C:\Program Files\Linux Containers\initrd.img" -PathType Leaf) {
+            copy "C:\Program Files\Linux Containers\initrd.img" "C:\Program Files\Linux Containers\initrd.old"
+            Write-Host -ForegroundColor Yellow "INFO: Backed up previous initrd.img to C:\Program Files\Linux Containers\initrd.old"
+        }
+        copy "$d`\initrd.img" "C:\Program Files\Linux Containers\initrd.img"
+        Write-Host -ForegroundColor Yellow "INFO: Restart the docker daemon to pick up the new image"
+    }
 	
-	if ($Install) {
-		if (Test-Path "C:\Program Files\Linux Containers\initrd.img" -PathType Leaf) {
-			copy "C:\Program Files\Linux Containers\initrd.img" "C:\Program Files\Linux Containers\initrd.old"
-			Write-Host -ForegroundColor Yellow "INFO: Backed up previous initrd.img to C:\Program Files\Linux Containers\initrd.old"
-		}
-		copy "$d`\initrd.img" "C:\Program Files\Linux Containers\initrd.img"
-		Write-Host -ForegroundColor Yellow "INFO: Restart the docker daemon to pick up the new image"
-	}
 }
 Catch [Exception] {
     Throw $_

--- a/service/Makefile
+++ b/service/Makefile
@@ -14,7 +14,7 @@ GCS_TOOLS=\
 	netnscfg \
 	remotefs
 
-GO_FLAGS=-pkgdir "$(WORKDIR)/pkg"
+GO_FLAGS=-pkgdir "$(WORKDIR)/pkg" -ldflags "-s -w"
 
 all: gobins
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 
- Fixes the alignment (tabs to 4 spaces)
- Builds the binaries with `ldflags -s -w` to strip debugging info. Makes them significantly smaller
- Adds commit/branch to initrd.img 