### PR TITLE
Add /git.commit to docs

### DIFF
--- a/docs/customosbuildinstructions.md
+++ b/docs/customosbuildinstructions.md
@@ -131,6 +131,11 @@ Here are the expected contents of each subdirectory /file
 
     - Debugging tools: mostly from busybox tool set
 
+7. **/** :
+
+    - /gcs.commit Optional file containing the commit id of Microsoft/opengcs
+
+ 
 
 # Supported LCOW custom Linux OS packaging formats
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Allows docker and other management clients to be able to read this file to get the commit ID of opengcs in an initrd.img (or VHDX). Added it to the documentation.