### PR TITLE
Support FROM scratch

### DIFF
--- a/service/gcsutils/libtar2vhd/tar2vhd.go
+++ b/service/gcsutils/libtar2vhd/tar2vhd.go
@@ -1,11 +1,14 @@
 package libtar2vhd
 
 import (
+	"bufio"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/pkg/archive"
 	"github.com/sirupsen/logrus"
@@ -106,15 +109,62 @@ func VHD2Tar(in io.Reader, out io.Writer, options *Options) (int64, error) {
 // VHDX2Tar takes in a folder (can be mounted from an attached VHDX) and returns a tar stream
 // containing the contents of the folder. It also returns the size of the tar stream.
 func VHDX2Tar(mntPath string, out io.Writer, options *Options) (int64, error) {
-	// The actual files are located in <mnt_path>/upper
-	readerResult, err := archive.TarWithOptions(filepath.Join(mntPath, "upper"), options.TarOpts)
+	// If using overlay, the actual files are located in <mnt_path>/upper.
+	// `FROM SCRATCH` uses a regular ext4 mount.
+	logrus.Infof("VHDX2Tar on mount path %s", mntPath)
+	pm, err := os.Open("/proc/mounts")
 	if err != nil {
+		e := fmt.Errorf("failed to open /proc/mounts %s", err)
+		logrus.Errorf(e.Error())
+		return 0, e
+	}
+	defer pm.Close()
+	scanner := bufio.NewScanner(pm)
+	overlay := true
+	for scanner.Scan() {
+		logrus.Infof("scanning mount line %q", scanner.Text())
+		if strings.Contains(scanner.Text(), mntPath) {
+			logrus.Info("mount line contains the mount path")
+			if !strings.Contains(scanner.Text(), "overlay") {
+				logrus.Info("mount line does not contain overlay, but still could be overlay - looking for 'upper'")
+				s, err := os.Stat(filepath.Join(mntPath, "upper"))
+				if err != nil {
+					if os.IsNotExist(err) {
+						logrus.Info("'upper' does not exist, so definitely not overlay")
+						overlay = false
+						break
+					}
+					e := fmt.Errorf("failed to stat %s: %s", filepath.Join(mntPath, "upper"), err)
+					logrus.Errorf(e.Error())
+					return 0, e
+				}
+				if !s.IsDir() {
+					logrus.Info("'upper' is not a directory, so not overlay")
+					overlay = false
+				}
+			}
+			// Exit loop as found the line which has the mount path
+			break
+		}
+	}
+	if overlay {
+		mntPath = filepath.Join(mntPath, "upper")
+		logrus.Infof("is overlay so updated mount path to %s", mntPath)
+	}
+
+	readerResult, err := archive.TarWithOptions(mntPath, options.TarOpts)
+	if err != nil {
+		e := fmt.Errorf("failed to TarWithOptions %s (%+v): %s", mntPath, options.TarOpts, err)
+		logrus.Errorf(e.Error())
 		return 0, err
 	}
 
 	retSize, err := io.Copy(out, readerResult)
 	if err != nil {
+		e := fmt.Errorf("failed to io.Copy the tar stream back to the caller: %s", err)
+		logrus.Errorf(e.Error())
 		return 0, err
 	}
+	logrus.Infof("copied %d bytes of tarstream back", retSize)
 	return retSize, nil
 }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

This is the matching part to what is now in docker master.

```
PS E:\docker\build\scratch> docker build -t scratch --no-cache .
Sending build context to Docker daemon    810kB
Step 1/5 : FROM scratch as s
 --->
Step 2/5 : ADD testfile.txt /
 ---> 19c126503c15
Step 3/5 : FROM alpine
 ---> 3fd9065eaf02
Step 4/5 : COPY --from=s /testfile.txt /testfile.txt
 ---> 0638b263f2fb
Step 5/5 : RUN ls -l /
 ---> Running in 961e3c771084
total 52
drwxr-xr-x    2 root     root          4096 Jan  9 19:37 bin
drwxr-xr-x    5 root     root           340 Mar 19 19:51 dev
drwxr-xr-x    1 root     root            60 Mar 19 19:51 etc
drwxr-xr-x    2 root     root          4096 Jan  9 19:37 home
drwxr-xr-x    5 root     root          4096 Jan  9 19:37 lib
drwxr-xr-x    5 root     root          4096 Jan  9 19:37 media
drwxr-xr-x    2 root     root          4096 Jan  9 19:37 mnt
dr-xr-xr-x   73 root     root             0 Mar 19 19:51 proc
drwx------    2 root     root          4096 Jan  9 19:37 root
drwxr-xr-x    2 root     root          4096 Jan  9 19:37 run
drwxr-xr-x    2 root     root          4096 Jan  9 19:37 sbin
drwxr-xr-x    2 root     root          4096 Jan  9 19:37 srv
dr-xr-xr-x   13 root     root             0 Mar 19 19:51 sys
-rw-rw-rw-    1 root     root            25 May  4  2017 testfile.txt
drwxrwxrwt    2 root     root          4096 Jan  9 19:37 tmp
drwxr-xr-x    7 root     root          4096 Jan  9 19:37 usr
drwxr-xr-x   11 root     root          4096 Jan  9 19:37 var
Removing intermediate container 961e3c771084
 ---> 1a444a623d90
Successfully built 1a444a623d90
Successfully tagged scratch:latest
PS E:\docker\build\scratch>
```