### PR TITLE
Unplug mapped disks from inside the VM

### DIFF
--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -813,6 +813,9 @@ func (c *gcsCore) removeMappedVirtualDisks(id string, disks []prot.MappedVirtual
 	if err := c.unmountMappedVirtualDisks(disks); err != nil {
 		return errors.Wrapf(err, "failed to mount mapped virtual disks for container %s", id)
 	}
+	if err := c.unplugMappedVirtualDisks(disks); err != nil {
+		return errors.Wrapf(err, "failed to unplug mapped virtual disks for container %s", id)
+	}
 	for _, disk := range disks {
 		containerEntry.RemoveMappedVirtualDisk(disk)
 	}

--- a/service/gcs/core/gcs/storage.go
+++ b/service/gcs/core/gcs/storage.go
@@ -253,6 +253,18 @@ func (c *gcsCore) unmountMappedVirtualDisks(disks []prot.MappedVirtualDisk) erro
 	return nil
 }
 
+// unplugMappedVirtualDisks tells the OS that the mapped virtual disks will be removed soon, allowing the OS to perform some cleanup before the unplug event.
+// This assumes only one SCSI controller.
+func (c *gcsCore) unplugMappedVirtualDisks(disks []prot.MappedVirtualDisk) error {
+	for _, disk := range disks {
+		scsiID := fmt.Sprintf("0:0:0:%d", disk.Lun)
+		if err := c.OS.UnplugSCSIDisk(scsiID); err != nil {
+			return errors.Wrapf(err, "failed to unplug %s", scsiID)
+		}
+	}
+	return nil
+}
+
 // mountMappedDirectory mounts the given mapped directory using a Plan9
 // filesystem with the given options.
 func (c *gcsCore) mountMappedDirectory(dir *prot.MappedDirectory) error {

--- a/service/gcs/oslayer/mockos/mockos.go
+++ b/service/gcs/oslayer/mockos/mockos.go
@@ -188,6 +188,9 @@ func (o *mockOS) Mount(source string, target string, fstype string, flags uintpt
 func (o *mockOS) Unmount(target string, flags int) (err error) {
 	return nil
 }
+func (o *mockOS) UnplugSCSIDisk(scsiID string) (err error) {
+	return nil
+}
 func (o *mockOS) PathExists(name string) (bool, error) {
 	return true, nil
 }

--- a/service/gcs/oslayer/oslayer.go
+++ b/service/gcs/oslayer/oslayer.go
@@ -69,6 +69,7 @@ type OS interface {
 	ReadDir(dirname string) ([]os.FileInfo, error)
 	Mount(source string, target string, fstype string, flags uintptr, data string) (err error)
 	Unmount(target string, flags int) (err error)
+	UnplugSCSIDisk(scsiID string) (err error)
 	PathExists(name string) (bool, error)
 	PathIsMounted(name string) (bool, error)
 	Link(oldname, newname string) error

--- a/service/gcs/oslayer/realos/realos.go
+++ b/service/gcs/oslayer/realos/realos.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -180,6 +181,18 @@ func (o *realOS) Mount(source string, target string, fstype string, flags uintpt
 }
 func (o *realOS) Unmount(target string, flags int) (err error) {
 	if err := syscall.Unmount(target, flags); err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
+}
+func (o *realOS) UnplugSCSIDisk(scsiID string) (err error) {
+	f, err := os.OpenFile(filepath.Join("/sys/bus/scsi/devices", scsiID, "delete"), os.O_WRONLY, 0644)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	defer f.Close()
+
+	if _, err := f.Write([]byte("1\n")); err != nil {
 		return errors.WithStack(err)
 	}
 	return nil


### PR DESCRIPTION
Currently, when removing mapped disks the disks are unmounted
before the host removes them. The removal from the host is just
a notification and the Linux kernel then performs the clean-up
asynchronously.

If we unplug a larger number of disks this may take some time
and there is no way for the host to know when the clean-up is
finished and new/different disks can be added.

This patch tells the Linux kernel that we are about to unplug
the disks after they were unmounted, allowing it to perform
the clean-up in advance.

This fixes the issue in globalmode where a mkdir fails within
the Linux utility/service VM.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>