### PR TITLE
Build rootfs.tar.gz

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+Dockerfile
+client
+docs
+kernel
+.travis.yml
+*.ps1
+LICENSE
+*.md
+*.exe
+*.vhd*

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@
 # Ignore gcs bin directory
 service/bin/
 service/pkg/
+
+*.img
+*.vhd
+*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,17 @@
 # platform=linux
 #
 # John Howard Feb 2018. Based on github.com/linuxkit/lcow/pkg/init-lcow/Dockerfile
-# This Dockerfile builds initrd.img from local opengcs sources. It can be used
-# on a Windows machine building in LCOW mode.
+# This Dockerfile builds initrd.img and rootfs.tar.gz from local opengcs sources. 
+# It can be used on a Windows machine running in LCOW mode.
 #
 # Manual steps:
 #   git clone https://github.com/Microsoft/opengcs c:\go\src\github.com\Microsoft\opengcs
 #   cd c:\go\src\github.com\Microsoft\opengcs
 #   docker build --platform=linux -t opengcs .
-#   docker run --rm -v c:\initrd:/out opengcs cp /initrd.img /out
-#   copy c:\initrd\initrd.img "c:\Program Files\Linux Containers"
+#   docker run --rm -v c:\target:/out opengcs cp /initrd.img /out
+#   docker run --rm -v c:\target:/out opengcs cp /rootfs.tar.gz /out
+#   copy c:\target\initrd.img "c:\Program Files\Linux Containers"
+#   <TODO: Additional step to generate VHD from rootfs.tar.gz and install>
 #   <Restart the docker daemon to pick up the new initrd>
 
 FROM linuxkit/runc:7c39a68490a12cde830e1922f171c451fb08e731 AS runc
@@ -18,26 +20,41 @@ FROM linuxkit/alpine:b1a36f0dd41e60142dd84dab7cd333ce7da1d1f8
 ENV GOPATH=/go PATH=$PATH:/go/bin
 RUN \
     # Create all the directories
-    mkdir -p /initrd/etc/apk &&  \
-    mkdir -p /initrd/bin && \
-    mkdir -p /initrd/sbin && \
+    mkdir -p /target/etc/apk &&  \
+    mkdir -p /target/bin && \
+    mkdir -p /target/sbin && \
     mkdir -p /go/src/github.com/Microsoft/opengcs && \
     \
-    # Generate base filesystem in /initrd
-    cp -r /etc/apk/* /initrd/etc/apk/ && \
-    apk add --no-cache --initdb -p /initrd alpine-baselayout busybox e2fsprogs musl && \
-    rm -rf /initrd/etc/apk /initrd/lib/apk /initrd/var/cache && \
+    # Generate base filesystem in /target
+    cp -r /etc/apk/* /target/etc/apk/ && \
+    apk add --no-cache --initdb -p /target alpine-baselayout busybox e2fsprogs musl && \
+    rm -rf /target/etc/apk /target/lib/apk /target/var/cache && \
     \
     # Install the build packages
     apk add --no-cache build-base curl git go musl-dev && \
     \
     # Grab udhcpc_config.script
-    curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /initrd/sbin/udhcpc_config.script && \
-    chmod ugo+rx /initrd/sbin/udhcpc_config.script
-COPY --from=runc / /initrd/
-ADD https://raw.githubusercontent.com/linuxkit/lcow/b17397d2a79e1f375e2dd3a03daf34b39f8ee880/pkg/init-lcow/init /initrd/
+    curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /target/sbin/udhcpc_config.script && \
+    chmod ugo+rx /target/sbin/udhcpc_config.script
+COPY --from=runc / /target/
+
+# Add the init script
+ADD https://raw.githubusercontent.com/linuxkit/lcow/b17397d2a79e1f375e2dd3a03daf34b39f8ee880/pkg/init-lcow/init /target/
+
+# Add the sources for opengcs
 COPY . /go/src/github.com/Microsoft/opengcs
-RUN chmod 0755 /initrd/init && \
-    cd /go/src/github.com/Microsoft/opengcs/service && make && cp -r bin /initrd && \
-    cd .. && git rev-parse HEAD > /initrd/gcs.commit && git rev-parse --abbrev-ref HEAD > /initrd/gcs.branch && \
-    cd /initrd && ls -lR && find . | cpio -o --format="newc" | gzip -c > /initrd.img
+
+# Build the binaries and add them to the target
+RUN chmod 0755 /target/init && \
+    cd /go/src/github.com/Microsoft/opengcs/service && \
+	make && \
+	cp -r bin /target && \
+    cd .. && \
+	git rev-parse              HEAD > /target/gcs.commit && \
+	git rev-parse --abbrev-ref HEAD > /target/gcs.branch
+
+# Generate the root filesystem in both initrd.img and rootfs.tar.gz formats
+RUN cd /target && \
+	find . | cpio -o --format="newc" | gzip -c > /initrd.img && \
+	tar -c . | gzip -c > /rootfs.tar.gz && \
+	printf "\nTargets:\n" && ls -l /initrd.img /rootfs.tar.gz && printf "\n"

--- a/build.ps1
+++ b/build.ps1
@@ -1,6 +1,6 @@
 <#
 .NOTES
-    Summary: Simple wrapper to build a local initrd.img from sources and optionally install it.
+    Summary: Simple wrapper to build a local initrd.img and rootfs.tar.gz from sources and optionally install it.
 
     License: See https://github.com/Microsoft/opengcs/blob/master/LICENSE
 
@@ -29,18 +29,20 @@ Try {
     if ( $LastExitCode -ne 0 ) {
         Throw "failed to build opengcs image"
     }
-    
-    Write-Host -ForegroundColor Yellow "INFO: Copying initrd.img from opengcs:latest image"
-    $d=New-TemporaryDirectory
+
+    $d=New-TemporaryDirectory    
+    Write-Host -ForegroundColor Yellow "INFO: Copying targets to $d"
     docker run --rm -v $d`:/out opengcs cp /initrd.img /out
     if ( $LastExitCode -ne 0 ) {
         Throw "failed to copy initrd.img to $d"
     }
-    $generated = "$d`\initrd.img"
-    $size=(Get-Item $generated).Length
-    Write-Host -ForegroundColor Yellow "INFO: Created $generated"
-    Write-Host -ForegroundColor Yellow "INFO: Size $size bytes"
-    
+    docker run --rm -v $d`:/out opengcs cp /rootfs.tar.gz /out
+    if ( $LastExitCode -ne 0 ) {
+        Throw "failed to copy rootfs.tar.gz to $d"
+    }
+
+	Write-Host -ForegroundColor Yellow "INFO: Use rootfs2vhd in Microsoft/hcsshim to make a rootfs VHD if needed"
+ 
     if ($Install) {
         if (Test-Path "C:\Program Files\Linux Containers\initrd.img" -PathType Leaf) {
             copy "C:\Program Files\Linux Containers\initrd.img" "C:\Program Files\Linux Containers\initrd.old"


### PR DESCRIPTION
Signed-off-by: John Howard jhoward@microsoft.com

Updates to build `rootfs.tar.gz`. This can be used as the input to `rootfs2vhd` in the hcsshim repo (not yet PR'd) to convert it to a VHD suitable for PMEM booting an LCOW utility VM.

@jterry75 When merged, can you rebase the multicontainer branch to include this?