### PR TITLE
Stop calling kernel bootx64.efi. It confuses everybody!

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -110,7 +110,7 @@ func ParseOptions(options []string) (Options, error) {
 		rOpts.Vhdx = filepath.Join(rOpts.KirdPath, `uvm.vhdx`)
 	}
 	if rOpts.KernelFile == "" {
-		rOpts.KernelFile = `bootx64.efi`
+		rOpts.KernelFile = `kernel`
 	}
 	if rOpts.InitrdFile == "" {
 		rOpts.InitrdFile = `initrd.img`


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Now that 4 people have got thoroughly confused by the naming of this file, let's just call it what it really is. 

@rn Once PR'd into moby/moby, it will affect deployment through D4W.