### PR TITLE
vsockexec: Don't reorder getopt args

### DIFF
--- a/vsockexec/vsockexec.c
+++ b/vsockexec/vsockexec.c
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
     unsigned int ports[3] = {0};
     int sockets[3] = {-1, -1, -1};
     int c;
-    while ((c = getopt(argc, argv, "i:o:e:")) != -1) {
+    while ((c = getopt(argc, argv, "+i:o:e:")) != -1) {
         switch (c) {
         case 'i':
             ports[0] = strtoul(optarg, NULL, 10);


### PR DESCRIPTION
When linking against glibc, getopt will scan for arguments after the
first-non-flag argument, which causes problems when passing a command
without using -- (which does not appear to be possible on the Linux
kernel command line).