### PR TITLE
Build rootfs2vhd and run it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GCS_TOOLS=\
 
 .PHONY: all always rootfs test
 
-all: out/initrd.img out/rootfs.tar.gz
+all: out/initrd.img out/rootfs.tar.gz out/rootfs2vhd.exe
 
 test:
 	cd $(SRCROOT) && go test ./service/gcsutils/...
@@ -39,6 +39,7 @@ rootfs: .rootfs-done
 	git -C $(SRCROOT) rev-parse HEAD > rootfs/gcs.commit && \
 	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/gcs.branch
 	touch .rootfs-done
+	ls -lR rootfs
 
 out/rootfs.tar.gz: $(BASE) .rootfs-done
 	@mkdir -p out
@@ -49,6 +50,11 @@ out/initrd.img: out/rootfs.tar.gz
 	# Convert from the rootfs tar to newc cpio
 	bsdtar -zcf $@ --format newc @out/rootfs.tar.gz
 
+out/rootfs2vhd.exe:
+	# Compile rootfs2vhd for Windows
+	env GOOS=windows GOARCH=amd64 go get -u github.com/Microsoft/hcsshim/internal/cmd/rootfs2vhd
+	cp /go/bin/windows_amd64/rootfs2vhd.exe out/
+	
 bin/gcs.always: always
 	@mkdir -p bin
 	$(GO_BUILD) -o $@ github.com/Microsoft/opengcs/service/gcs

--- a/build.ps1
+++ b/build.ps1
@@ -1,11 +1,11 @@
 <#
 .NOTES
-    Summary: Simple wrapper to build a local initrd.img and rootfs.tar.gz from sources and optionally install it.
+    Summary: Simple wrapper to build a local initrd.img, rootfs.tar.gz and rootfs.vhd from sources and optionally install it.
 
     License: See https://github.com/Microsoft/opengcs/blob/master/LICENSE
 
 .Parameter Install
-    Installs the built initrd.img
+    Installs the built initrd.img and rootfs.vhd
 
 #>
 
@@ -31,13 +31,24 @@ Try {
     }
 
     $d=New-TemporaryDirectory
-    Write-Host -ForegroundColor Yellow "INFO: Copying targets to $d"
+    Write-Host -ForegroundColor Yellow "INFO: Compiling GCS and rootfs2vhd binaries"
     docker run --rm -v $d`:/build/out opengcs
     if ( $LastExitCode -ne 0 ) {
         Throw "failed to build"
     }
 
-	Write-Host -ForegroundColor Yellow "INFO: Use rootfs2vhd in Microsoft/hcsshim to make a rootfs VHD if needed"
+	if ([environment]::OSVersion.Version.Build -gt 17134) {
+		Write-Host -ForegroundColor Yellow "INFO: Generating rootfs.vhd"
+		pushd $d
+		.\rootfs2vhd
+		popd
+		if ( $LastExitCode -ne 0 ) {
+			Write-Warning "failed to convert to rootfs to VHD. Ignoring while tool still in progress"
+		}
+	} else {
+		Write-Warning "Skipping conversion of root file system to VHD - requires RS5+"
+	}
+	
 
     if ($Install) {
         if (Test-Path "C:\Program Files\Linux Containers\initrd.img" -PathType Leaf) {
@@ -45,9 +56,19 @@ Try {
             Write-Host -ForegroundColor Yellow "INFO: Backed up previous initrd.img to C:\Program Files\Linux Containers\initrd.old"
         }
         copy "$d`\initrd.img" "C:\Program Files\Linux Containers\initrd.img"
-        Write-Host -ForegroundColor Yellow "INFO: Restart the docker daemon to pick up the new image"
-    }
 
+        if (Test-Path "$d`\rootfs.vhd" -PathType Leaf) {
+			if (Test-Path "C:\Program Files\Linux Containers\rootfs.vhd" -PathType Leaf) {
+				copy "C:\Program Files\Linux Containers\rootfs.vhd" "C:\Program Files\Linux Containers\rootfs.old"
+				Write-Host -ForegroundColor Yellow "INFO: Backed up previous rootfs.vhd to C:\Program Files\Linux Containers\rootfs.old"
+			}
+			copy "$d`\rootfs.vhd" "C:\Program Files\Linux Containers\rootfs.vhd"
+		}
+
+        Write-Host -ForegroundColor Yellow "INFO: Restart the docker daemon to pick up the new filee"
+	}
+
+	Write-Host -ForegroundColor Yellow "INFO: Targets in $d"
 }
 Catch [Exception] {
     Throw $_


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 PTAL

Cross-compiles the rootfs2vhd.exe tool in the opengcs LCOW container, and the build script runs it if on an RS5+ machine. Currently any generated error is ignored, as the tool still has a dependency on New-VHD which may not be present (yes, it's on my list of TODOs....)