### PR TITLE
Add Makefile rule to build rootfs.vhd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ install:
   - docker build -t opengcs .
 
 script:
-  - docker run --privileged opengcs make -f /go/src/github.com/Microsoft/opengcs/Makefile all test
+  - docker run --privileged opengcs make -f /go/src/github.com/Microsoft/opengcs/Makefile all out/rootfs.vhd test

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     rm -rf /target/etc/apk /target/lib/apk /target/var/cache && \
     \
     # Install the build packages
-    apk add --no-cache build-base curl git go musl-dev linux-headers libarchive-tools && \
+    apk add --no-cache build-base curl git go musl-dev linux-headers libarchive-tools e2fsprogs && \
     \
     # Grab udhcpc_config.script
     curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /target/sbin/udhcpc_config.script && \

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,13 @@ out/initrd.img: out/rootfs.tar.gz
 	# Convert from the rootfs tar to newc cpio
 	bsdtar -zcf $@ --format newc @out/rootfs.tar.gz
 
+out/rootfs.vhd: out/rootfs.tar.gz bin/tar2vhd
+	@mkdir -p out
+	t=`mktemp` && zcat out/rootfs.tar.gz | bin/tar2vhd > "$$t" && mv $$t $@
+
+bin/tar2vhd: bin/gcstools
+	ln -s gcstools $@
+
 bin/gcs.always: always
 	@mkdir -p bin
 	$(GO_BUILD) -o $@ github.com/Microsoft/opengcs/service/gcs

--- a/service/gcsutils/gcstools/tar2vhd_main.go
+++ b/service/gcsutils/gcstools/tar2vhd_main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/Microsoft/opengcs/service/gcsutils/gcstools/commoncli"
@@ -36,6 +37,7 @@ func tar2vhd() error {
 
 func tar2vhdMain() {
 	if err := tar2vhd(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 	os.Exit(0)

--- a/service/gcsutils/tarlib/tardisk.go
+++ b/service/gcsutils/tarlib/tardisk.go
@@ -148,8 +148,11 @@ func CreateTarDisk(in io.Reader,
 	}
 
 	// Mount the disk and remove the lost+found folder that might appear from mkfs
-	if err := exec.Command("mount", "-t", "ext4", "-o", "loop", disk.Name(), mntFolder).Run(); err != nil {
+	if _, err := exec.Command("mount", "-t", "ext4", "-o", "loop", disk.Name(), mntFolder).Output(); err != nil {
 		logrus.Infof("failed mount -o loop %s", err)
+		if ee, ok := err.(*exec.ExitError); ok {
+			return 0, fmt.Errorf("mount failed: %s: %s", err, ee.Stderr)
+		}
 		return 0, err
 	}
 	defer exec.Command("umount", mntFolder).Run()


### PR DESCRIPTION
This rule requires root or something like a privileged Docker container in order to run.

We can update build.ps1 to use this once Docker LCOW supports configuring capabilities and the device cgroup rules.