### PR TITLE
Timeout netnscfg, logging, message to HCS on init process failure.

### DIFF
--- a/service/gcs/core/core.go
+++ b/service/gcs/core/core.go
@@ -13,7 +13,7 @@ import (
 // containers. However, it is also easily mocked out for testing.
 type Core interface {
 	CreateContainer(id string, info prot.VMHostedContainerSettings) error
-	ExecProcess(id string, info prot.ProcessParameters, conSettings stdio.ConnectionSettings) (pid int, err error)
+	ExecProcess(id string, info prot.ProcessParameters, conSettings stdio.ConnectionSettings) (pid int, execInitErrorDone chan<- struct{}, err error)
 	SignalContainer(id string, signal oslayer.Signal) error
 	SignalProcess(pid int, options prot.SignalProcessOptions) error
 	GetProperties(id string, query string) (*prot.Properties, error)

--- a/service/gcs/core/gcs/networking.go
+++ b/service/gcs/core/gcs/networking.go
@@ -33,6 +33,7 @@ func (c *gcsCore) configureAdapterInNamespace(container runtime.Container, adapt
 		"-nspid", fmt.Sprintf("%d", nspid),
 		"-cfg", string(cfg)).CombinedOutput()
 	if err != nil {
+		logrus.Debugf("netnscfg failed: %s (%s)", out, err)
 		return errors.Wrapf(err, "failed to configure network adapter %s: %s", adapter.AdapterInstanceID, out)
 	}
 	logrus.Debugf("netnscfg output:\n%s", out)

--- a/service/gcs/core/gcs/uvm.go
+++ b/service/gcs/core/gcs/uvm.go
@@ -292,6 +292,7 @@ func (c *Container) Start(conSettings stdio.ConnectionSettings) (int, error) {
 }
 
 func (c *Container) ExecProcess(process *oci.Process, conSettings stdio.ConnectionSettings) (int, error) {
+	logrus.Debugf("container::ExecProcess %+v", *process)
 	stdioSet, err := stdio.Connect(c.vsock, conSettings)
 	if err != nil {
 		return -1, err

--- a/service/gcs/core/mockcore/mockcore.go
+++ b/service/gcs/core/mockcore/mockcore.go
@@ -133,13 +133,13 @@ func (c *MockCore) CreateContainer(id string, settings prot.VMHostedContainerSet
 }
 
 // ExecProcess captures its arguments and returns pid 101.
-func (c *MockCore) ExecProcess(id string, params prot.ProcessParameters, conSettings stdio.ConnectionSettings) (pid int, err error) {
+func (c *MockCore) ExecProcess(id string, params prot.ProcessParameters, conSettings stdio.ConnectionSettings) (pid int, execInitErrorDone chan<- struct{}, err error) {
 	c.LastExecProcess = ExecProcessCall{
 		ID:                 id,
 		Params:             params,
 		ConnectionSettings: conSettings,
 	}
-	return 101, c.behaviorResult()
+	return 101, nil, c.behaviorResult()
 }
 
 // SignalContainer captures its arguments.

--- a/service/gcsutils/gcstools/netnsConfig.go
+++ b/service/gcsutils/gcstools/netnsConfig.go
@@ -11,6 +11,7 @@ package main
 // output itself.
 
 import (
+	"bytes"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -18,8 +19,10 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"time"
 
 	"github.com/Microsoft/opengcs/service/gcs/prot"
+	"github.com/Microsoft/opengcs/service/gcsutils/gcstools/commoncli"
 	log "github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"github.com/vishvananda/netns"
@@ -27,8 +30,11 @@ import (
 
 func netnsConfigMain() {
 	if err := netnsConfig(); err != nil {
-		log.Fatal("netnsConfig returned: ", err)
+		log.Errorf("netnsConfig returned: %s", err)
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(-1)
 	}
+	log.Info("netnsConfig succeeded")
 	os.Exit(0)
 }
 
@@ -36,8 +42,12 @@ func netnsConfig() error {
 	ifStr := flag.String("if", "", "Interface/Adapter to move/configure")
 	nspid := flag.Int("nspid", -1, "Process ID (to locate netns")
 	cfgStr := flag.String("cfg", "", "Adapter configuration (json)")
+	logArgs := commoncli.SetFlagsForLogging()
 
 	flag.Parse()
+	if err := commoncli.SetupLogging(logArgs...); err != nil {
+		return err
+	}
 	if *ifStr == "" || *nspid == -1 || *cfgStr == "" {
 		return fmt.Errorf("All three arguments must be specified")
 	}
@@ -50,7 +60,7 @@ func netnsConfig() error {
 	if a.NatEnabled {
 		log.Infof("Configure %s in %d with: %s/%d gw=%s", *ifStr, *nspid, a.AllocatedIPAddress, a.HostIPPrefixLength, a.HostIPAddress)
 	} else {
-		log.Infof("Configure %s in %s with DHCP", *ifStr, *nspid)
+		log.Infof("Configure %s in %d with DHCP", *ifStr, *nspid)
 	}
 
 	// Lock the OS Thread so we don't accidentally switch namespaces
@@ -58,11 +68,13 @@ func netnsConfig() error {
 	defer runtime.UnlockOSThread()
 
 	// Stash current network namespace away and make sure we enter it as we leave
+	log.Infof("Obtaining current namespace")
 	origNS, err := netns.Get()
 	if err != nil {
 		return fmt.Errorf("netns.Get() failed: %v", err)
 	}
 	defer origNS.Close()
+	log.Infof("Original namespace %v", origNS)
 
 	// Get a reference to the new network namespace
 	ns, err := netns.GetFromPid(*nspid)
@@ -70,6 +82,7 @@ func netnsConfig() error {
 		return fmt.Errorf("netns.GetFromPid(%d) failed: %v", *nspid, err)
 	}
 	defer ns.Close()
+	log.Infof("New network namespace from PID %d is %v", *nspid, ns)
 
 	// Get a reference to the interface and make sure it's down
 	link, err := netlink.LinkByName(*ifStr)
@@ -93,6 +106,7 @@ func netnsConfig() error {
 	}
 
 	// Re-Get a reference to the interface (it may be a different ID in the new namespace)
+	log.Infof("Getting reference to interface")
 	link, err = netlink.LinkByName(*ifStr)
 	if err != nil {
 		return fmt.Errorf("netlink.LinkByName(%s) failed: %v", *ifStr, err)
@@ -100,7 +114,9 @@ func netnsConfig() error {
 
 	// User requested non-default MTU size
 	if a.EncapOverhead != 0 {
+		log.Info("EncapOverhead non-zero, will set MTU")
 		mtu := link.Attrs().MTU - int(a.EncapOverhead)
+		log.Infof("mtu %d", mtu)
 		if err = netlink.LinkSetMTU(link, mtu); err != nil {
 			return fmt.Errorf("netlink.LinkSetMTU(%#v, %d) failed: %v", link, mtu, err)
 		}
@@ -108,6 +124,7 @@ func netnsConfig() error {
 
 	// Configure the interface
 	if a.NatEnabled {
+		log.Info("Nat enabled - configuring interface")
 		metric := 1
 		if a.EnableLowMetric {
 			metric = 500
@@ -155,14 +172,42 @@ func netnsConfig() error {
 			}
 		}
 	} else {
-		err := exec.Command(
-			"udhcpc",
-			"-q",
-			"-i", *ifStr,
-			"-s", "/sbin/udhcpc_config.script").Run()
-		if err != nil {
-			return fmt.Errorf("udhcpc failed: %v", err)
+		log.Infof("Execing udhcpc with timeout...")
+		cmd := exec.Command("udhcpc", "-q", "-i", *ifStr, "-s", "/sbin/udhcpc_config.script")
+
+		done := make(chan error)
+		go func() {
+			done <- cmd.Wait()
+		}()
+		defer close(done)
+
+		select {
+		case <-time.After(time.Duration(30 * time.Second)):
+			var cos string
+			co, err := cmd.CombinedOutput() // In case it has written something
+			if err != nil {
+				cos = string(co[:])
+			}
+			cmd.Process.Kill()
+			log.Infof("udhcpc timed out [%s]", cos)
+			return fmt.Errorf("udhcpc timed out. Failed to get DHCP address: %s", cos)
+		case err := <-done:
+			var cos string
+			co, err := cmd.CombinedOutput() // Something should be on stderr
+			if err != nil {
+				cos = string(co[:])
+			}
+			if err != nil {
+				log.Infof("udhcpc failed %s [%s]", err, cos)
+				return fmt.Errorf("process failed: %s (%s)", err, cos)
+			}
 		}
+		var cos string
+		co, err := cmd.CombinedOutput()
+		if err != nil {
+			cos = string(co[:])
+		}
+		log.Debugf("udhcpc succeeded: %s", cos)
 	}
 
 	// Add some debug logging


### PR DESCRIPTION
@jterry75 Clean-up of the branch we were working on earlier.

Makes sure HCS gets a message on failure.

Adds a bunch of debug logging around waitgroup increment/decrement as impossible to diagnose

Times out after 30 seconds if unable to get a DHCP address rather than hang indefinitely in transparent networking mode

Logging in netnscfg (currently to /tmp/netnscfg.log, but better than nothing at all)

Fixes netnscfg to write to stderr on failure and actually exit with non-zero exit code on failure.


