### PR TITLE
Fixes v1 shutdown failure code

### DIFF
--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -475,7 +475,7 @@ func (c *gcsCore) SignalContainer(id string, signal oslayer.Signal) error {
 
 	containerEntry := c.getContainer(id)
 	if containerEntry == nil {
-		return errors.WithStack(gcserr.NewContainerDoesNotExistError(id))
+		return gcserr.WrapHresult(errors.WithStack(gcserr.NewContainerDoesNotExistError(id)), gcserr.HrVmcomputeSystemAlreadyStopped)
 	}
 
 	if containerEntry.container != nil {

--- a/service/gcs/gcserr/errors.go
+++ b/service/gcs/gcserr/errors.go
@@ -28,6 +28,9 @@ const (
 	// HrVmcomputeInvalidJSON is the HRESULT for failing to unmarshal a json
 	// string.
 	HrVmcomputeInvalidJSON = Hresult(-1070137075) // 0xC037010D
+	// HrVmcomputeSystemAlreadyStopped is the HRESULT for calling
+	// Shutdown/Terminate on a machine that is already in that state.
+	HrVmcomputeSystemAlreadyStopped = Hresult(-1070137072) // 0xC0370110
 	// HrVmcomputeProtocolError is the HRESULT for an invalid protocol
 	// request/response.
 	HrVmcomputeProtocolError = Hresult(-1070137071) // 0xC0370111


### PR DESCRIPTION
1. Fixes an issue where when signaling a container either via Shutdown
or Terminate the HCS previously would return an error that indicated the
Compute System was already stopped. We now have the gcs return this
HRESULT directly to honor the existing hcsshim behavior for determining
if the signal error is a real one or not.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>