### PR TITLE
Remove ProcessV2 Version property requirement

### DIFF
--- a/service/gcs/bridge/bridge_handler_test.go
+++ b/service/gcs/bridge/bridge_handler_test.go
@@ -515,7 +515,9 @@ func Test_ExecProcess_Container_CoreFails_Failure(t *testing.T) {
 
 	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
 
+	uvm := gcs.NewHost(nil, nil, nil)
 	tb := &Bridge{
+		hostState: uvm,
 		coreint: &mockcore.MockCore{
 			Behavior: mockcore.Error,
 		},
@@ -540,9 +542,11 @@ func Test_ExecProcess_Container_CoreSucceeds_Success(t *testing.T) {
 
 	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
 
+	uvm := gcs.NewHost(nil, nil, nil)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{
-		coreint: mc,
+		hostState: uvm,
+		coreint:   mc,
 	}
 	tb.execProcess(rw, req)
 

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -806,7 +806,6 @@ type VMHostedContainerSettingsV2 struct {
 // In this case, don't specify the OCISpecification field, but specify all
 // other fields. This is the same as if it were an external process.
 type ProcessParameters struct {
-	SchemaVersion SchemaVersion
 	// CommandLine is a space separated list of command line parameters. For
 	// example, the command which sleeps for 100 seconds would be represented by
 	// the CommandLine string "sleep 100".


### PR DESCRIPTION
Removes the SchemaVersion property requirement from the ProcessV2 schema
and gathers the version number from the ContainerID itself that was used
at create time.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>