### PR TITLE
Fix DebugGCS time.Duration parameter to work across all platforms

### DIFF
--- a/client/process.go
+++ b/client/process.go
@@ -158,7 +158,7 @@ func (config *Config) DebugGCS() {
 		logrus.Debugln("benign failure getting gcs logs: ", err)
 	}
 	if proc != nil {
-		proc.WaitTimeout(time.Duration(int(time.Second) * 30))
+		proc.WaitTimeout(time.Duration(int64(time.Second) * 30))
 	}
 	logrus.Debugf("GCS Debugging:\n%s\n\nEnd GCS Debugging", strings.TrimSpace(out.String()))
 }

--- a/client/process.go
+++ b/client/process.go
@@ -158,7 +158,7 @@ func (config *Config) DebugGCS() {
 		logrus.Debugln("benign failure getting gcs logs: ", err)
 	}
 	if proc != nil {
-		proc.WaitTimeout(time.Duration(int64(time.Second) * 30))
+		proc.WaitTimeout(time.Duration(time.Second * 30))
 	}
 	logrus.Debugf("GCS Debugging:\n%s\n\nEnd GCS Debugging", strings.TrimSpace(out.String()))
 }


### PR DESCRIPTION
Fix time.Duration parameter to have the right size across all platforms. Work done by askariv.