### PR TITLE
Supports V2 exec external process with a V2 schema

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -566,7 +566,10 @@ func (b *Bridge) execProcess(w ResponseWriter, r *Request) {
 	var c *gcspkg.Container
 	var err error
 	if params.IsExternal {
-		logrus.Debugf("bridge::execProcess: IsExternal Calling b.coreint.RunExternalProcess")
+		logrus.Debugf("bridge::execProcess: IsExternal: calling b.coreint.RunExternalProcess")
+		pid, err = b.coreint.RunExternalProcess(params, conSettings)
+	} else if request.ContainerID == gcspkg.UVMContainerID {
+		logrus.Debugf("bridge::execProcess: UVMContainerID: calling b.coreint.RunExternalProcess")
 		pid, err = b.coreint.RunExternalProcess(params, conSettings)
 	} else if c, err = b.hostState.GetContainer(request.ContainerID); err == nil {
 		// We found a V2 container. Treat this as a V2 process.

--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -416,7 +416,7 @@ func (c *gcsCore) ExecProcess(id string, params prot.ProcessParameters, connecti
 			return -1, execInitErrorDone, err
 		}
 	} else {
-		var ociProcess oci.Process
+		var ociProcess *oci.Process
 		ociProcess, err = processParametersToOCI(params)
 		if err != nil {
 			return -1, nil, err
@@ -568,7 +568,7 @@ func (c *gcsCore) RunExternalProcess(params prot.ProcessParameters, conSettings 
 		}
 	}()
 
-	var ociProcess oci.Process
+	var ociProcess *oci.Process
 	ociProcess, err = processParametersToOCI(params)
 	if err != nil {
 		return -1, err
@@ -875,18 +875,22 @@ func (c *gcsCore) setupMappedDirectories(id string, dirs []prot.MappedDirectory)
 // oci.Process struct for OCI version 1.0.0. Since ProcessParameters
 // doesn't include various fields which are available in oci.Process, default
 // values for these fields are chosen.
-func processParametersToOCI(params prot.ProcessParameters) (oci.Process, error) {
+func processParametersToOCI(params prot.ProcessParameters) (*oci.Process, error) {
+	if params.OCIProcess != nil {
+		return params.OCIProcess, nil
+	}
+
 	var args []string
 	if len(params.CommandArgs) == 0 {
 		var err error
 		args, err = processParamCommandLineToOCIArgs(params.CommandLine)
 		if err != nil {
-			return oci.Process{}, err
+			return new(oci.Process), err
 		}
 	} else {
 		args = params.CommandArgs
 	}
-	return oci.Process{
+	return &oci.Process{
 		Args:     args,
 		Cwd:      params.WorkingDirectory,
 		Env:      processParamEnvToOCIEnv(params.Environment),

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -33,7 +33,7 @@ var _ = Describe("GCS", func() {
 		Describe("calling processParametersToOCI", func() {
 			var (
 				params  prot.ProcessParameters
-				process oci.Process
+				process *oci.Process
 			)
 			JustBeforeEach(func() {
 				process, err = processParametersToOCI(params)
@@ -44,7 +44,7 @@ var _ = Describe("GCS", func() {
 				})
 				AssertNoError()
 				It("should output an oci.Process with non-defaulted fields zeroed", func() {
-					Expect(process).To(Equal(oci.Process{
+					Expect(*process).To(Equal(oci.Process{
 						Args: []string{},
 						Env:  []string{},
 						User: oci.User{UID: 0, GID: 0},
@@ -139,7 +139,7 @@ var _ = Describe("GCS", func() {
 				})
 				AssertNoError()
 				It("should output an oci.Process which matches the input values", func() {
-					Expect(process).To(Equal(oci.Process{
+					Expect(*process).To(Equal(oci.Process{
 						Args:     []string{"sh", "-c", "sleep", "20"},
 						Cwd:      "/home/user/work",
 						Env:      []string{"PATH=/this/is/my/path"},
@@ -237,7 +237,7 @@ var _ = Describe("GCS", func() {
 				})
 				AssertNoError()
 				It("should output an oci.Process which matches the input values", func() {
-					Expect(process).To(Equal(oci.Process{
+					Expect(*process).To(Equal(oci.Process{
 						Args:     []string{"sh", "-c", "sleep", "20"},
 						Cwd:      "/home/user/work",
 						Env:      []string{"PATH=/this/is/my/path"},

--- a/service/gcs/core/gcs/uvm.go
+++ b/service/gcs/core/gcs/uvm.go
@@ -304,7 +304,7 @@ func (c *Container) ExecProcess(process *oci.Process, conSettings stdio.Connecti
 	c.processesWg.Add(1)
 	c.processesMutex.Unlock()
 
-	p, err := c.container.ExecProcess(*process, stdioSet)
+	p, err := c.container.ExecProcess(process, stdioSet)
 	if err != nil {
 		// We failed to exec any process. Remove our early count increment.
 		c.processesMutex.Lock()

--- a/service/gcs/runtime/mockruntime/mockruntime.go
+++ b/service/gcs/runtime/mockruntime/mockruntime.go
@@ -54,7 +54,7 @@ func (c *container) PipeRelay() *stdio.PipeRelay {
 	return nil
 }
 
-func (c *container) ExecProcess(process oci.Process, stdioSet *stdio.ConnectionSet) (p runtime.Process, err error) {
+func (c *container) ExecProcess(process *oci.Process, stdioSet *stdio.ConnectionSet) (p runtime.Process, err error) {
 	return c, nil
 }
 

--- a/service/gcs/runtime/runc/runc.go
+++ b/service/gcs/runtime/runc/runc.go
@@ -132,7 +132,7 @@ func (c *container) Start() error {
 
 // ExecProcess executes a new process, represented as an OCI process struct,
 // inside an already-running container.
-func (c *container) ExecProcess(process oci.Process, stdioSet *stdio.ConnectionSet) (p runtime.Process, err error) {
+func (c *container) ExecProcess(process *oci.Process, stdioSet *stdio.ConnectionSet) (p runtime.Process, err error) {
 	p, err = c.runExecCommand(process, stdioSet)
 	if err != nil {
 		return nil, err
@@ -495,7 +495,7 @@ func (r *runcRuntime) hasTerminal(bundlePath string) (bool, error) {
 }
 
 // runExecCommand sets up the arguments for calling runc exec.
-func (c *container) runExecCommand(processDef oci.Process, stdioSet *stdio.ConnectionSet) (p runtime.Process, err error) {
+func (c *container) runExecCommand(processDef *oci.Process, stdioSet *stdio.ConnectionSet) (p runtime.Process, err error) {
 	// Create a temporary random directory to store the process's files.
 	tempProcessDir, err := ioutil.TempDir(containerFilesDir, c.id)
 	if err != nil {

--- a/service/gcs/runtime/runc/runc_test.go
+++ b/service/gcs/runtime/runc/runc_test.go
@@ -455,40 +455,40 @@ var _ = Describe("runC", func() {
 
 				Describe("performing post-Start operations", func() {
 					var (
-						shProcess         oci.Process
-						catProcess        oci.Process
-						errProcess        oci.Process
-						shortSleepProcess oci.Process
-						longSleepProcess  oci.Process
+						shProcess         *oci.Process
+						catProcess        *oci.Process
+						errProcess        *oci.Process
+						shortSleepProcess *oci.Process
+						longSleepProcess  *oci.Process
 						connSetClient     *stdio.ConnectionSet
 						connSetServer     *stdio.ConnectionSet
 					)
 					BeforeEach(func() {
-						shProcess = oci.Process{
+						shProcess = &oci.Process{
 							Terminal: true,
 							Cwd:      "/",
 							Args:     []string{"sh"},
 							Env:      []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 						}
-						catProcess = oci.Process{
+						catProcess = &oci.Process{
 							Terminal: false,
 							Cwd:      "/",
 							Args:     []string{"cat"},
 							Env:      []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 						}
-						errProcess = oci.Process{
+						errProcess = &oci.Process{
 							Terminal: false,
 							Cwd:      "/",
 							Args:     []string{"ls", "fake directory"},
 							Env:      []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 						}
-						shortSleepProcess = oci.Process{
+						shortSleepProcess = &oci.Process{
 							Terminal: false,
 							Cwd:      "/",
 							Args:     []string{"sleep", "0.1"},
 							Env:      []string{"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"},
 						}
-						longSleepProcess = oci.Process{
+						longSleepProcess = &oci.Process{
 							Terminal: false,
 							Cwd:      "/",
 							Args:     []string{"sleep", "1000"},
@@ -502,7 +502,7 @@ var _ = Describe("runC", func() {
 
 					Describe("executing a process in a container", func() {
 						var (
-							process oci.Process
+							process *oci.Process
 						)
 						JustBeforeEach(func() {
 							_, err = c.ExecProcess(process, connSetClient)

--- a/service/gcs/runtime/runtime.go
+++ b/service/gcs/runtime/runtime.go
@@ -53,7 +53,7 @@ type Container interface {
 	ID() string
 	Exists() (bool, error)
 	Start() error
-	ExecProcess(process oci.Process, stdioSet *stdio.ConnectionSet) (p Process, err error)
+	ExecProcess(process *oci.Process, stdioSet *stdio.ConnectionSet) (p Process, err error)
 	Kill(signal oslayer.Signal) error
 	Pause() error
 	Resume() error


### PR DESCRIPTION
Adds support for a V2 exec external process that uses an oci.Process
spec rather than the v1 schema of cmd/args.

Resolves: #246

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>