### PR TITLE
Change HotRemove NIC to warning instead of error

### DIFF
--- a/service/gcs/core/gcs/uvm.go
+++ b/service/gcs/core/gcs/uvm.go
@@ -623,7 +623,11 @@ func (c *Container) RemoveNetworkAdapter(id string) error {
 	}).Info("opengcs::Container::RemoveNetworkAdapter")
 
 	// TODO: JTERRY75 - Implement removal if we ever need to support hot remove.
-	return errors.New("not implemented")
+	logrus.WithFields(logrus.Fields{
+		"cid":               c.id,
+		"adapterInstanceID": id,
+	}).Warning("opengcs::Container::RemoveNetworkAdapter - Not implemented")
+	return nil
 }
 
 // Process is a struct that defines the lifetime and operations associated with


### PR DESCRIPTION
We don't actually fully support HotRemove NIC from namespace but since
this only happens on teardown we likely don't need it. For now just log
this as a warning rather than returning an error because we do
actually try to safe remove it from the host side on shutdown which is
returning an error that is silently ignored.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>