### PR TITLE
Bump go to 1.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 FROM linuxkit/runc:069d5cd3cc4f0aec70e4af53aed5d27a21c79c35 AS runc
 FROM busybox AS busybox
 
-FROM golang:1.11.5-alpine3.9
+FROM golang:1.12.1-alpine3.9
 ENV GOPATH=/go PATH=$PATH:/go/bin SRC=/go/src/github.com/Microsoft/opengcs
 WORKDIR /build
 RUN \

--- a/build.ps1
+++ b/build.ps1
@@ -11,7 +11,8 @@
 
 
 param(
-    [Parameter(Mandatory=$false)][switch]$Install
+    [Parameter(Mandatory=$false)][switch]$Install,
+	[Parameter(Mandatory=$false)][switch]$NoCache
 )
 
 $ErrorActionPreference = 'Stop'
@@ -30,7 +31,10 @@ Try {
     $d=New-TemporaryDirectory
     echo "Commit:`t$commit`nRepo:`tmicrosoft/opengcs`nBranch:`t$branch`nBuilt:`t$(date)" > $d\opengcsversion.txt
 
-    &docker build --platform=linux -t opengcs .
+    if ($NoCache -eq $true) {
+        $cache="--no-cache"
+    }
+    &docker build --platform=linux $cache -t opengcs .
     if ( $LastExitCode -ne 0 ) {
         Throw "failed to build opengcs image"
     }


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

@jterry75 - bumps the golang for local build to 1.12.1 now it's released. Done some basic validation on the resulting initrd.img and can't see anything obvious that doesn't work.

Also adds a `-NoCache` option to build.ps1 as that's been annoying me since forever....