### PR TITLE
Exclude lost+found from tar stream

### DIFF
--- a/service/gcsutils/gcstools/commoncli/common.go
+++ b/service/gcsutils/gcstools/commoncli/common.go
@@ -57,7 +57,10 @@ func SetupVHD2TarLibOptions(args ...*string) (*libvhd2tar.Options, error) {
 	}
 
 	options := &libvhd2tar.Options{
-		TarOpts:       &archive.TarOptions{WhiteoutFormat: format},
+		TarOpts: &archive.TarOptions{
+			WhiteoutFormat:  format,
+			ExcludePatterns: []string{`lost\+found`},
+		},
 		TempDirectory: tmpdir,
 	}
 


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

So that when there really are no filesystem differences to generate a VHD from the tarstream, we are taking account of the fact that we're using EXT4.

@jterry75 @jstarks PTAL.