### PR TITLE
Upgrade to cmd.ProcessState.ExitCode() with golang 1.12

### DIFF
--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -629,7 +629,7 @@ func (c *gcsCore) RunExternalProcess(params prot.ProcessParameters, conSettings 
 			// important.
 			logrus.Error(errors.Wrap(werr, "failed call to Wait for external process"))
 		}
-		exitCode := cmd.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+		exitCode := cmd.ProcessState.ExitCode()
 		logrus.Infof("external process %d exited with exit status %d", cmd.Process.Pid, exitCode)
 
 		if relay != nil {

--- a/service/gcs/runtime/runc/runc.go
+++ b/service/gcs/runtime/runc/runc.go
@@ -406,7 +406,7 @@ func (r *runcRuntime) waitOnProcess(pid int) (int, error) {
 		return -1, errors.Wrapf(err, "failed waiting on process %d", pid)
 	}
 
-	return state.Sys().(syscall.WaitStatus).ExitStatus(), nil
+	return state.ExitCode(), nil
 }
 
 func (p *process) Wait() (int, error) {


### PR DESCRIPTION
Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>