### PR TITLE
gcs: Prevent GCS crashing when external process exits

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -282,7 +282,9 @@ int reap_until(pid_t until_pid) {
                 }
                 return WEXITSTATUS(status);
             }
-            fputs("child exited by signal\n", stderr);
+            fputs("child exited by signal: ", stderr);
+            fputs(strsignal(WTERMSIG(status)), stderr);
+            fputs("\n", stderr);
             return 128 + WTERMSIG(status);
         }
     }


### PR DESCRIPTION
Currently, when the GCS launches an external process with a pty, that
pty becomes the controlling terminal for the GCS. This causes the kernel
to deliver a SIGHUP signal when the pty is torn down, which causes the
GCS to exit.

To resolve this, the GCS explicitly opens the terminal with O_NOCTTY so
to avoid making it the controlling terminal. It also now marks the child
as the leader of a new session and has the child make the new pty the
controlling terminal of the child process.