### PR TITLE
Makefile: append to archive manually

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     rm -rf /target/etc/apk /target/lib/apk /target/var/cache && \
     \
     # Install the build packages
-    apk add --no-cache build-base curl git musl-dev libarchive-tools e2fsprogs && \
+    apk add --no-cache build-base curl git musl-dev libarchive-tools e2fsprogs file && \
     \
     # Grab udhcpc_config.script
     curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /target/sbin/udhcpc_config.script && \

--- a/hack/catcpio.sh
+++ b/hack/catcpio.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+dir="`mktemp -d`"
+trap 'rm -rf "$dir"' EXIT
+
+for file; do
+    if ! [ -f "$file" ]; then
+        echo file not found: "$file"
+        exit 1
+    fi
+    case `file -bz "$file"` in
+        "ASCII cpio archive"*"(gzip compressed data"*)
+            gunzip -c "$file" | (cd "$dir" && cpio -i) ;;
+        "ASCII cpio archive"*)
+            cat "$file" | (cd "$dir" && cpio -i) ;;
+        *)
+            tar -xf "$file" -C "$dir" ;;
+    esac
+done
+cd "$dir" && find . | cpio --create --format=newc -R 0:0


### PR DESCRIPTION
The bsdtar append step do not interoperate well with some archives or
with our tar2ext4 tool. Extract and rearchive files rather than trying
to append or convert in place.

This strips any ownership information from the initrd image, so all
files will be owned by root. This should be acceptable because /dev is
always mounted as devtmpfs, and no other files should need special
owners.