### PR TITLE
vsockexec: Remove dependency on Linux headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     rm -rf /target/etc/apk /target/lib/apk /target/var/cache && \
     \
     # Install the build packages
-    apk add --no-cache build-base curl git musl-dev linux-headers libarchive-tools e2fsprogs && \
+    apk add --no-cache build-base curl git musl-dev libarchive-tools e2fsprogs && \
     \
     # Grab udhcpc_config.script
     curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /target/sbin/udhcpc_config.script && \

--- a/vsockexec/vsockexec.c
+++ b/vsockexec/vsockexec.c
@@ -3,7 +3,6 @@
 
 #include <errno.h>
 #include <sys/socket.h>
-#include <linux/vm_sockets.h>
 #include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,6 +14,19 @@ static const int tcpmode = 1;
 #else
 static const int tcpmode;
 #endif
+
+struct sockaddr_vm {
+	unsigned short svm_family;
+	unsigned short svm_reserved1;
+	unsigned int svm_port;
+	unsigned int svm_cid;
+	unsigned char svm_zero[sizeof(struct sockaddr) -
+			       sizeof(sa_family_t) -
+			       sizeof(unsigned short) -
+			       sizeof(unsigned int) - sizeof(unsigned int)];
+};
+
+#define VMADDR_CID_HOST 2
 
 static int openvsock(unsigned int cid, unsigned int port)
 {


### PR DESCRIPTION
This makes it possible to build easily with musl-gcc.