### PR TITLE
Return proper ContainerExit result

### DIFF
--- a/internal/runtime/hcsv2/process.go
+++ b/internal/runtime/hcsv2/process.go
@@ -16,12 +16,17 @@ import (
 // Process is a struct that defines the lifetime and operations associated with
 // an oci.Process.
 type Process struct {
+	// c is the owning container
+	c    *Container
 	spec *oci.Process
 	// cid is the container id that owns this process.
 	cid string
 
 	process runtime.Process
 	pid     uint32
+	// init is `true` if this is the container process itself
+	init bool
+
 	// This is only valid post the exitWg
 	exitCode int
 	exitWg   sync.WaitGroup
@@ -42,10 +47,12 @@ type Process struct {
 // outstanding wait for process exit, and post exit an outstanding wait for
 // process cleanup to release all resources once at least 1 waiter has
 // successfully written the exit response.
-func newProcess(c *Container, spec *oci.Process, process runtime.Process, pid uint32) *Process {
+func newProcess(c *Container, spec *oci.Process, process runtime.Process, pid uint32, init bool) *Process {
 	p := &Process{
+		c:       c,
 		spec:    spec,
 		process: process,
+		init:    init,
 		cid:     c.id,
 		pid:     pid,
 	}
@@ -108,6 +115,9 @@ func (p *Process) Kill(signal syscall.Signal) error {
 			return gcserr.NewHresultError(gcserr.HrErrNotFound)
 		}
 		return err
+	}
+	if p.init {
+		p.c.setExitType(signal)
 	}
 	return nil
 }

--- a/internal/runtime/hcsv2/uvm.go
+++ b/internal/runtime/hcsv2/uvm.go
@@ -234,11 +234,12 @@ func (h *Host) CreateContainer(id string, settings *prot.VMHostedContainerSettin
 		vsock:     h.vsock,
 		spec:      settings.OCISpecification,
 		container: con,
+		exitType:  prot.NtUnexpectedExit,
 		processes: make(map[uint32]*Process),
 	}
 	// Add the WG count for the init process
 	c.processesWg.Add(1)
-	c.initProcess = newProcess(c, settings.OCISpecification.Process, con.(runtime.Process), uint32(c.container.Pid()))
+	c.initProcess = newProcess(c, settings.OCISpecification.Process, con.(runtime.Process), uint32(c.container.Pid()), true)
 
 	// For the sandbox move all adapters into the network namespace
 	if isSandboxOrStandalone && networkNamespace != "" {

--- a/service/gcs/bridge/bridge_handler_test.go
+++ b/service/gcs/bridge/bridge_handler_test.go
@@ -376,7 +376,7 @@ func Test_CreateContainer_Success_WaitContainer_Success(t *testing.T) {
 		if cn.Operation != prot.AoNone {
 			t.Fatal("publish response had invalid operation")
 		}
-		if cn.Result != -1 {
+		if cn.Result != 0 {
 			t.Fatal("publish response had invalid result")
 		}
 	}()

--- a/service/gcs/core/core.go
+++ b/service/gcs/core/core.go
@@ -21,6 +21,6 @@ type Core interface {
 	RunExternalProcess(info prot.ProcessParameters, conSettings stdio.ConnectionSettings) (pid int, err error)
 	ModifySettings(id string, request *prot.ResourceModificationRequestResponse) error
 	ResizeConsole(pid int, height, width uint16) error
-	WaitContainer(id string) (func() int, error)
+	WaitContainer(id string) (func() prot.NotificationType, error)
 	WaitProcess(pid int) (<-chan int, chan<- bool, error)
 }

--- a/service/gcs/core/gcs/gcs.go
+++ b/service/gcs/core/gcs/gcs.go
@@ -738,9 +738,9 @@ func (c *gcsCore) ResizeConsole(pid int, height, width uint16) error {
 }
 
 // WaitContainer returns a function that can be used to sucessfully wait for a
-// container exit code. This will only return after all writers on WaitProcess
-// have completed. On error the container id was not a valid container.
-func (c *gcsCore) WaitContainer(id string) (func() int, error) {
+// container. This will only return after all writers on WaitProcess have
+// completed. On error the container id was not a valid container.
+func (c *gcsCore) WaitContainer(id string) (func() prot.NotificationType, error) {
 	c.containerCacheMutex.Lock()
 	entry := c.getContainer(id)
 	if entry == nil {
@@ -749,11 +749,12 @@ func (c *gcsCore) WaitContainer(id string) (func() int, error) {
 	}
 	c.containerCacheMutex.Unlock()
 
-	f := func() int {
+	f := func() prot.NotificationType {
 		logrus.Debugf("gcscore::WaitContainer waiting on init process waitgroup")
 		entry.initProcess.writersWg.Wait()
 		logrus.Debugf("gcscore::WaitContainer init process waitgroup count has dropped to zero")
-		return entry.initProcess.exitCode
+		// v1 only supported unexpected exit
+		return prot.NtUnexpectedExit
 	}
 
 	return f, nil

--- a/service/gcs/core/gcs/gcs_test.go
+++ b/service/gcs/core/gcs/gcs_test.go
@@ -796,10 +796,10 @@ var _ = Describe("GCS", func() {
 			})
 			Describe("calling wait container", func() {
 				JustBeforeEach(func() {
-					var exitCodeFn func() int
-					exitCodeFn, err = coreint.WaitContainer(containerID)
+					var waitFn func() prot.NotificationType
+					waitFn, err = coreint.WaitContainer(containerID)
 					if err == nil {
-						exitCodeFn()
+						waitFn()
 					}
 				})
 				Context("container does not exist", func() {

--- a/service/gcs/core/mockcore/mockcore.go
+++ b/service/gcs/core/mockcore/mockcore.go
@@ -195,12 +195,12 @@ func (c *MockCore) ResizeConsole(pid int, height, width uint16) error {
 }
 
 // WaitContainer captures its arguments and returns a nil error.
-func (c *MockCore) WaitContainer(id string) (func() int, error) {
+func (c *MockCore) WaitContainer(id string) (func() prot.NotificationType, error) {
 	c.LastWaitContainer = WaitContainerCall{
 		ID: id,
 	}
 	c.WaitContainerWg.Done()
-	return func() int { return -1 }, c.behaviorResult()
+	return func() prot.NotificationType { return prot.NtUnexpectedExit }, c.behaviorResult()
 }
 
 // WaitProcess captures its arguments and returns a nil error.


### PR DESCRIPTION
1. Fixes a bug where we were returning an exit code in the ContainerExit.Result
field which was incorrect. This is an HRESULT value of the Wait Result not the
exit code which is returned at Process.Wait.

2. Implements v2 to handle Graceful/Forced exit instead of just Unexpected when
the client is responsible for the SIGTERM/SIGKILL that stops the container.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>