### PR TITLE
gcs: Include nano seconds in JSON log output

### DIFF
--- a/service/gcs/main.go
+++ b/service/gcs/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/Microsoft/opengcs/internal/runtime/hcsv2"
 	"github.com/Microsoft/opengcs/service/gcs/bridge"
@@ -51,7 +52,9 @@ func main() {
 	case "text":
 		// retain logrus's default.
 	case "json":
-		logrus.SetFormatter(new(logrus.JSONFormatter))
+		logrus.SetFormatter(&logrus.JSONFormatter{
+			TimestampFormat: time.RFC3339Nano, // include ns for accurate comparisons on the host
+		})
 	default:
 		logrus.WithFields(logrus.Fields{
 			"log-format": *logFormat,


### PR DESCRIPTION
The logrus JSON output defaults to only second granularity in the
timestamp field. Nano seconds are necessary to accurately measure
guest-side event durations when the host is not keeping up with log
output.