### PR TITLE
Makefile: Only rebuild Go targets if a dependency has changed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,19 @@ BASE:=base.tar.gz
 
 GO:=go
 GO_FLAGS:=-ldflags "-s -w" # strip Go binaries
-
 CGO_ENABLED:=0
+GOMODVENDOR:=
+
 CFLAGS:=-O2 -Wall
 LDFLAGS:=-static -s # strip C binaries
 
-GO_BUILD=CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(GO_FLAGS)
-SRCROOT=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+GO_FLAGS_EXTRA:=
+ifeq "$(GOMODVENDOR)" "1"
+GO_FLAGS_EXTRA += -mod=vendor
+endif
+GO_BUILD:=CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(GO_FLAGS) $(GO_FLAGS_EXTRA)
+
+SRCROOT=$(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 # The link aliases for gcstools
 GCS_TOOLS=\
@@ -22,21 +28,21 @@ GCS_TOOLS=\
 all: out/initrd.img out/rootfs.tar.gz
 
 clean:
-	find -name '*.o' -print0 | xargs -0 rm
-	rm bin/*
+	find -name '*.o' -print0 | xargs -0 -r rm
+	rm -rf bin deps rootfs out
 
 test:
 	cd $(SRCROOT) && go test ./service/gcsutils/...
 	cd $(SRCROOT)/service/gcs && ginkgo -r -keepGoing
 
-out/delta.tar.gz: bin/init bin/vsockexec bin/gcs bin/gcstools Makefile
+out/delta.tar.gz: bin/init bin/vsockexec bin/service/gcs bin/service/gcsutils/gcstools Makefile
 	@mkdir -p out
 	rm -rf rootfs
 	mkdir -p rootfs/bin/
 	cp bin/init rootfs/
 	cp bin/vsockexec rootfs/bin/
-	cp bin/gcs rootfs/bin/
-	cp bin/gcstools rootfs/bin/
+	cp bin/service/gcs rootfs/bin/
+	cp bin/service/gcsutils/gcstools rootfs/bin/
 	for tool in $(GCS_TOOLS); do ln -s gcstools rootfs/bin/$$tool; done
 	git -C $(SRCROOT) rev-parse HEAD > rootfs/gcs.commit && \
 	git -C $(SRCROOT) rev-parse --abbrev-ref HEAD > rootfs/gcs.branch
@@ -51,13 +57,20 @@ out/initrd.img: $(BASE) out/delta.tar.gz $(SRCROOT)/hack/catcpio.sh
 	gzip -c out/initrd.img.uncompressed > $@
 	rm out/initrd.img.uncompressed
 
-bin/gcs.always: always
-	@mkdir -p bin
-	$(GO_BUILD) -o $@ github.com/Microsoft/opengcs/service/gcs
+include deps/service/gcs.gomake
+include deps/service/gcsutils/gcstools.gomake
 
-bin/gcstools.always: always
-	@mkdir -p bin
-	$(GO_BUILD) -o $@ github.com/Microsoft/opengcs/service/gcsutils/gcstools
+# Implicit rule for includes that define Go targets.
+%.gomake: $(SRCROOT)/Makefile
+	@mkdir -p $(dir $@)
+	@echo $(@:deps/%.gomake=bin/%): $(SRCROOT)/hack/gomakedeps.sh > $@.new
+	@echo -e '\t@mkdir -p $$(dir $$@) $(dir $@)' >> $@.new
+	@echo -e '\t$$(GO_BUILD) -o $$@.new $$(SRCROOT)/$$(@:bin/%=%)' >> $@.new
+	@echo -e '\t$$(SRCROOT)/hack/gomakedeps.sh $$@ $$(SRCROOT)/$$(@:bin/%=%) $$(GO_FLAGS) $$(GO_FLAGS_EXTRA) > $(@:%.gomake=%.godeps).new' >> $@.new
+	@echo -e '\tmv $(@:%.gomake=%.godeps).new $(@:%.gomake=%.godeps)' >> $@.new
+	@echo -e '\tmv $$@.new $$@' >> $@.new
+	@echo -e '-include $(@:%.gomake=%.godeps)' >> $@.new
+	mv $@.new $@
 
 VPATH=$(SRCROOT)
 
@@ -72,9 +85,3 @@ bin/init: init/init.o
 %.o: %.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(CPPFLAGS) -c -o $@ $<
-
-# For programs are always rebuilt, so don't update the actual result file if the
-# result of the compilation did not change.
-%: %.always
-	@if ! cmp -s $@ $< ; then cp $< $@ ; fi
-	@rm $<

--- a/hack/gomakedeps.sh
+++ b/hack/gomakedeps.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Creates Makefile rules that enumerate all the input files
+# for the Go package provided on the command line.
+
+set -e
+
+target_bin="$1"
+target_pkg="$2"
+shift 2
+fmt=$(cat <<EOF
+{{ if not .Standard }}
+$target_bin: {{\$dir := .Dir}}{{ range .GoFiles }}{{\$dir}}/{{.}} {{end}}
+{{if .Module}}$target_bin: {{.Module.GoMod}}{{end}}
+{{end}}
+EOF
+)
+
+go list "$@" -f '{{ .ImportPath }} {{ join .Deps "\n" }}' "$target_pkg" |
+    xargs go list "$@" -find -f "$fmt"


### PR DESCRIPTION
This works by retrieving the list of dependencies from Go after building
a Go binary.