### PR TITLE
Makefile: Fixes to run in Debian stretch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,19 +57,19 @@ out/initrd.img: $(BASE) out/delta.tar.gz $(SRCROOT)/hack/catcpio.sh
 	gzip -c out/initrd.img.uncompressed > $@
 	rm out/initrd.img.uncompressed
 
-include deps/service/gcs.gomake
-include deps/service/gcsutils/gcstools.gomake
+-include deps/service/gcs.gomake
+-include deps/service/gcsutils/gcstools.gomake
 
 # Implicit rule for includes that define Go targets.
 %.gomake: $(SRCROOT)/Makefile
 	@mkdir -p $(dir $@)
-	@echo $(@:deps/%.gomake=bin/%): $(SRCROOT)/hack/gomakedeps.sh > $@.new
-	@echo -e '\t@mkdir -p $$(dir $$@) $(dir $@)' >> $@.new
-	@echo -e '\t$$(GO_BUILD) -o $$@.new $$(SRCROOT)/$$(@:bin/%=%)' >> $@.new
-	@echo -e '\t$$(SRCROOT)/hack/gomakedeps.sh $$@ $$(SRCROOT)/$$(@:bin/%=%) $$(GO_FLAGS) $$(GO_FLAGS_EXTRA) > $(@:%.gomake=%.godeps).new' >> $@.new
-	@echo -e '\tmv $(@:%.gomake=%.godeps).new $(@:%.gomake=%.godeps)' >> $@.new
-	@echo -e '\tmv $$@.new $$@' >> $@.new
-	@echo -e '-include $(@:%.gomake=%.godeps)' >> $@.new
+	@/bin/echo $(@:deps/%.gomake=bin/%): $(SRCROOT)/hack/gomakedeps.sh > $@.new
+	@/bin/echo -e '\t@mkdir -p $$(dir $$@) $(dir $@)' >> $@.new
+	@/bin/echo -e '\t$$(GO_BUILD) -o $$@.new $$(SRCROOT)/$$(@:bin/%=%)' >> $@.new
+	@/bin/echo -e '\tGO="$(GO)" $$(SRCROOT)/hack/gomakedeps.sh $$@ $$(SRCROOT)/$$(@:bin/%=%) $$(GO_FLAGS) $$(GO_FLAGS_EXTRA) > $(@:%.gomake=%.godeps).new' >> $@.new
+	@/bin/echo -e '\tmv $(@:%.gomake=%.godeps).new $(@:%.gomake=%.godeps)' >> $@.new
+	@/bin/echo -e '\tmv $$@.new $$@' >> $@.new
+	@/bin/echo -e '-include $(@:%.gomake=%.godeps)' >> $@.new
 	mv $@.new $@
 
 VPATH=$(SRCROOT)

--- a/hack/gomakedeps.sh
+++ b/hack/gomakedeps.sh
@@ -4,6 +4,7 @@
 
 set -e
 
+GO="${GO:-go}"
 target_bin="$1"
 target_pkg="$2"
 shift 2
@@ -15,5 +16,5 @@ $target_bin: {{\$dir := .Dir}}{{ range .GoFiles }}{{\$dir}}/{{.}} {{end}}
 EOF
 )
 
-go list "$@" -f '{{ .ImportPath }} {{ join .Deps "\n" }}' "$target_pkg" |
-    xargs go list "$@" -find -f "$fmt"
+"$GO" list "$@" -f '{{ .ImportPath }} {{ join .Deps "\n" }}' "$target_pkg" |
+    xargs "$GO" list "$@" -find -f "$fmt"


### PR DESCRIPTION
This fixes a few limitations that prevent the Makefile from being used
in a Debian stretch environment. It also fixes uses of non-standard Go
paths.