### PR TITLE
gcs: Fill out ErrorMessage string for HCS external bridge

### DIFF
--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -963,6 +963,7 @@ func setErrorForResponseBase(response *prot.MessageResponseBase, errForResponse 
 		hresult = gcserr.HrFail
 	}
 	response.Result = int32(hresult)
+	response.ErrorMessage = errorMessage
 	newRecord := prot.ErrorRecord{
 		Result:       int32(hresult),
 		Message:      errorMessage,

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -642,6 +642,7 @@ type ErrorRecord struct {
 type MessageResponseBase struct {
 	Result       int32
 	ActivityID   string        `json:"ActivityId"`
+	ErrorMessage string        `json:",omitempty"` // Only used by hcsshim external bridge
 	ErrorRecords []ErrorRecord `json:",omitempty"`
 }
 


### PR DESCRIPTION
To make it unambiguous which string represents the user-actionable
error, return it in a new field in the bridge response.