### PR TITLE
rootfs: Convert from initrd by extracting and archiving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,11 @@ out/delta.tar.gz: bin/init bin/vsockexec bin/service/gcs bin/service/gcsutils/gc
 	rm -rf rootfs
 
 out/rootfs.tar.gz: out/initrd.img
-	bsdtar -zcf $@ @out/initrd.img
+	rm -rf rootfs-conv
+	mkdir rootfs-conv
+	gunzip -c out/initrd.img | (cd rootfs-conv && cpio -imd)
+	tar -zcf $@ -C rootfs-conv .
+	rm -rf rootfs-conv
 
 out/initrd.img: $(BASE) out/delta.tar.gz $(SRCROOT)/hack/catcpio.sh
 	$(SRCROOT)/hack/catcpio.sh "$(BASE)" out/delta.tar.gz > out/initrd.img.uncompressed


### PR DESCRIPTION
This fixes files that are hard linked in the root file system.

Before this change, bsdtar was used to convert the cpio initrd archive
to a tar file, but this failed for mkfs* files that are hard linked to
each other. This is arguably a bug in bsdtar, but it is complicated
because tar and cpio store hard linked files in reverse order from each
other (tar stores the payload in the first hard link, while cpio stores
the payload in the last link).