### PR TITLE
Simplify the bridge request/return pattern

### DIFF
--- a/service/gcs/bridge/bridge_handler_test.go
+++ b/service/gcs/bridge/bridge_handler_test.go
@@ -17,33 +17,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type testResponseWriter struct {
-	header         *prot.MessageHeader
-	response       interface{}
-	err            error
-	errActivityID  string
-	respWriteCount int
-}
-
-func (w *testResponseWriter) Header() *prot.MessageHeader {
-	return w.header
-}
-
-func (w *testResponseWriter) Write(r interface{}) {
-	w.response = r
-	w.respWriteCount++
-}
-
-func (w *testResponseWriter) Error(activityID string, err error) {
-	if activityID == "" {
-		activityID = "00000000-0000-0000-0000-000000000000"
-	}
-
-	w.errActivityID = activityID
-	w.err = err
-	w.respWriteCount++
-}
-
 func createRequest(t *testing.T, id prot.MessageIdentifier, ver prot.ProtocolVersion, message interface{}) *Request {
 	r := &Request{}
 
@@ -67,75 +40,28 @@ func createRequest(t *testing.T, id prot.MessageIdentifier, ver prot.ProtocolVer
 	return r
 }
 
-func createResponseWriter(r *Request) *testResponseWriter {
-	hdr := &prot.MessageHeader{
-		Type: prot.GetResponseIdentifier(r.Header.Type),
-		ID:   r.Header.ID,
+func verifyResponseError(t *testing.T, resp RequestResponse, err error) {
+	if resp != nil {
+		t.Fatalf("response was returned on expected error: %+v", resp)
 	}
-
-	return &testResponseWriter{header: hdr}
-}
-
-func setupRequestResponse(t *testing.T, id prot.MessageIdentifier, ver prot.ProtocolVersion, message interface{}) (*Request, *testResponseWriter) {
-	r := createRequest(t, id, ver, message)
-	rw := createResponseWriter(r)
-	return r, rw
-}
-
-func verifyResponseWriteCount(t *testing.T, rw *testResponseWriter) {
-	if rw.respWriteCount != 1 {
-		t.Fatalf("response was written (%d) times != 1", rw.respWriteCount)
+	if err == nil {
+		t.Fatal("expected valid error, got: nil")
 	}
 }
 
-func verifyResponseError(t *testing.T, rw *testResponseWriter) {
-	verifyResponseWriteCount(t, rw)
-	if rw.response != nil {
-		t.Fatal("response wrote a response not an error")
-	}
-	if rw.err == nil {
-		t.Fatal("response did not write an error")
+func verifyResponseJSONError(t *testing.T, resp RequestResponse, err error) {
+	verifyResponseError(t, resp, err)
+	if !strings.Contains(err.Error(), "failed to unmarshal JSON") {
+		t.Fatalf("response error %v, was not a json marshal error", err)
 	}
 }
 
-func verifyResponseJSONError(t *testing.T, rw *testResponseWriter) {
-	verifyResponseError(t, rw)
-	if !strings.Contains(rw.err.Error(), "failed to unmarshal JSON") {
-		t.Fatal("response error was not a json marshal error")
+func verifyResponseSuccess(t *testing.T, resp RequestResponse, err error) {
+	if resp == nil {
+		t.Fatal("expected valid response, got: nil")
 	}
-}
-
-func verifyResponseSuccess(t *testing.T, rw *testResponseWriter) {
-	verifyResponseWriteCount(t, rw)
-	if rw.err != nil {
-		t.Fatalf("response was an error response: %v", rw.err)
-	}
-	if rw.response == nil {
-		t.Fatal("response was a success but no message was included")
-	}
-}
-
-func verifyActivityIDEmptyGUID(t *testing.T, rw *testResponseWriter) {
-	if rw.err == nil {
-		t.Fatal("we only expect an empty activity ID on error cases")
-	}
-
-	if "00000000-0000-0000-0000-000000000000" != rw.errActivityID {
-		t.Fatalf("response activity ID (%s) was not equal to the empty guid '00000000-0000-0000-0000-000000000000'", rw.errActivityID)
-	}
-}
-
-func verifyActivityID(t *testing.T, req *prot.MessageBase, rw *testResponseWriter) {
-	var respActivityID string
-	if rw.err != nil {
-		respActivityID = rw.errActivityID
-	} else {
-		rwv := reflect.ValueOf(rw.response)
-		respActivityID = rwv.Elem().FieldByName("ActivityID").String()
-	}
-
-	if req.ActivityID != respActivityID {
-		t.Fatalf("response activity ID (%s) was not equal to request (%s) for 'Error' case", req.ActivityID, rw.errActivityID)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
 }
 
@@ -164,23 +90,21 @@ func newMessageUVMBase() *prot.MessageBase {
 }
 
 func Test_NegotiateProtocol_DuplicateCall_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, nil)
+	req := createRequest(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, nil)
 
 	tb := new(Bridge)
-	tb.negotiateProtocolV2(rw, req)
+	resp, err := tb.negotiateProtocolV2(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_NegotiateProtocol_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, nil)
+	req := createRequest(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, nil)
 
 	tb := new(Bridge)
-	tb.negotiateProtocolV2(rw, req)
+	resp, err := tb.negotiateProtocolV2(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_NegotiateProtocol_InvalidRange_Low_Failure(t *testing.T) {
@@ -190,13 +114,12 @@ func Test_NegotiateProtocol_InvalidRange_Low_Failure(t *testing.T) {
 		MaximumVersion: 3,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, r)
+	req := createRequest(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, r)
 
 	tb := new(Bridge)
-	tb.negotiateProtocolV2(rw, req)
+	resp, err := tb.negotiateProtocolV2(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_NegotiateProtocol_InvalidRange_High_Failure(t *testing.T) {
@@ -206,13 +129,12 @@ func Test_NegotiateProtocol_InvalidRange_High_Failure(t *testing.T) {
 		MaximumVersion: uint32(prot.PvMax) + 1,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, r)
+	req := createRequest(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, r)
 
 	tb := new(Bridge)
-	tb.negotiateProtocolV2(rw, req)
+	resp, err := tb.negotiateProtocolV2(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_NegotiateProtocol_ValidRange_Success(t *testing.T) {
@@ -222,17 +144,16 @@ func Test_NegotiateProtocol_ValidRange_Success(t *testing.T) {
 		MaximumVersion: uint32(prot.PvMax) + 1,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, r)
+	req := createRequest(t, prot.ComputeSystemNegotiateProtocolV1, prot.PvInvalid, r)
 
 	tb := new(Bridge)
-	tb.negotiateProtocolV2(rw, req)
+	resp, err := tb.negotiateProtocolV2(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 
-	resp := rw.response.(*prot.NegotiateProtocolResponse)
-	if resp.Version != uint32(prot.PvMax) {
-		t.Errorf("Invalid version number selected for response: %v", resp.Version)
+	npr := resp.(*prot.NegotiateProtocolResponse)
+	if npr.Version != uint32(prot.PvMax) {
+		t.Errorf("Invalid version number selected for response: %v", npr.Version)
 	}
 	// verify that the bridge global was updated
 	if tb.protVer != prot.PvMax {
@@ -241,13 +162,12 @@ func Test_NegotiateProtocol_ValidRange_Success(t *testing.T) {
 }
 
 func Test_CreateContainer_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemCreateV1, prot.PvInvalid, nil)
+	req := createRequest(t, prot.ComputeSystemCreateV1, prot.PvInvalid, nil)
 
 	tb := new(Bridge)
-	tb.createContainer(rw, req)
+	resp, err := tb.createContainer(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_CreateContainer_InvalidHostedJson_Failure(t *testing.T) {
@@ -255,13 +175,12 @@ func Test_CreateContainer_InvalidHostedJson_Failure(t *testing.T) {
 		MessageBase: newMessageBase(),
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
+	req := createRequest(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
 
 	tb := new(Bridge)
-	tb.createContainer(rw, req)
+	resp, err := tb.createContainer(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_CreateContainer_CoreCreateContainerFails_Failure(t *testing.T) {
@@ -270,25 +189,24 @@ func Test_CreateContainer_CoreCreateContainerFails_Failure(t *testing.T) {
 		ContainerConfig: "{}", // Just unmarshal to defaults
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
+	req := createRequest(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
 
 	tb := &Bridge{
 		coreint: &mockcore.MockCore{
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.createContainer(rw, req)
+	resp, err := tb.createContainer(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func createContainerConfig() (*prot.ContainerCreate, prot.VMHostedContainerSettings) {
 	hs := prot.VMHostedContainerSettings{
-		Layers:          []prot.Layer{prot.Layer{Path: "0"}, prot.Layer{Path: "1"}, prot.Layer{Path: "2"}},
+		Layers:          []prot.Layer{{Path: "0"}, {Path: "1"}, {Path: "2"}},
 		SandboxDataPath: "3",
 		MappedVirtualDisks: []prot.MappedVirtualDisk{
-			prot.MappedVirtualDisk{
+			{
 				ContainerPath:     "/path/inside/container",
 				Lun:               4,
 				CreateInUtilityVM: true,
@@ -296,7 +214,7 @@ func createContainerConfig() (*prot.ContainerCreate, prot.VMHostedContainerSetti
 			},
 		},
 		NetworkAdapters: []prot.NetworkAdapter{
-			prot.NetworkAdapter{
+			{
 				AdapterInstanceID:  "00000000-0000-0000-0000-000000000000",
 				FirewallEnabled:    false,
 				NatEnabled:         true,
@@ -323,16 +241,15 @@ func Test_CreateContainer_Success_WaitContainer_Failure(t *testing.T) {
 	logrus.SetOutput(ioutil.Discard)
 
 	r, hs := createContainerConfig()
-	req, rw := setupRequestResponse(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
+	req := createRequest(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.SingleSuccess}
 	mc.WaitContainerWg.Add(1)
 
 	tb := &Bridge{coreint: mc}
-	tb.createContainer(rw, req)
+	resp, err := tb.createContainer(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastCreateContainer.ID {
 		t.Fatal("last create container did not have the same container ID")
 	}
@@ -348,7 +265,7 @@ func Test_CreateContainer_Success_WaitContainer_Failure(t *testing.T) {
 
 func Test_CreateContainer_Success_WaitContainer_Success(t *testing.T) {
 	r, hs := createContainerConfig()
-	req, rw := setupRequestResponse(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
+	req := createRequest(t, prot.ComputeSystemCreateV1, prot.PvInvalid, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	mc.WaitContainerWg.Add(1)
@@ -381,9 +298,8 @@ func Test_CreateContainer_Success_WaitContainer_Success(t *testing.T) {
 		}
 	}()
 
-	b.createContainer(rw, req)
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	resp, err := b.createContainer(req)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastCreateContainer.ID {
 		t.Fatal("last create container did not have the same container ID")
 	}
@@ -405,36 +321,33 @@ func Test_CreateContainer_Success_WaitContainer_Success(t *testing.T) {
 }
 
 func Test_StartContainer_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemStartV1, prot.PvV4, nil)
+	req := createRequest(t, prot.ComputeSystemStartV1, prot.PvV4, nil)
 
 	b := new(Bridge)
-	b.startContainerV2(rw, req)
+	resp, err := b.startContainerV2(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_StartContainer_Success(t *testing.T) {
 	r := newMessageBase()
-	req, rw := setupRequestResponse(t, prot.ComputeSystemStartV1, prot.PvV4, r)
+	req := createRequest(t, prot.ComputeSystemStartV1, prot.PvV4, r)
 
 	b := new(Bridge)
 	b.responseChan = make(chan bridgeResponse)
 	defer close(b.responseChan)
 
-	b.startContainerV2(rw, req)
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r, rw)
+	resp, err := b.startContainerV2(req)
+	verifyResponseSuccess(t, resp, err)
 }
 
 func Test_ExecProcess_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.execProcess(rw, req)
+	resp, err := tb.execProcess(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_ExecProcess_InvalidProcessParameters_Failure(t *testing.T) {
@@ -445,13 +358,12 @@ func Test_ExecProcess_InvalidProcessParameters_Failure(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
 
 	tb := new(Bridge)
-	tb.execProcess(rw, req)
+	resp, err := tb.execProcess(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_ExecProcess_External_CoreFails_Failure(t *testing.T) {
@@ -466,17 +378,16 @@ func Test_ExecProcess_External_CoreFails_Failure(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
 
 	tb := &Bridge{
 		coreint: &mockcore.MockCore{
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.execProcess(rw, req)
+	resp, err := tb.execProcess(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_ExecProcess_External_CoreSucceeds_Success(t *testing.T) {
@@ -491,15 +402,14 @@ func Test_ExecProcess_External_CoreSucceeds_Success(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{
 		coreint: mc,
 	}
-	tb.execProcess(rw, req)
+	resp, err := tb.execProcess(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if !reflect.DeepEqual(pp, mc.LastRunExternalProcess.Params) {
 		t.Fatal("last run external process did not have equal params structs")
 	}
@@ -513,7 +423,7 @@ func Test_ExecProcess_Container_CoreFails_Failure(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -522,10 +432,9 @@ func Test_ExecProcess_Container_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.execProcess(rw, req)
+	resp, err := tb.execProcess(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_ExecProcess_Container_CoreSucceeds_Success(t *testing.T) {
@@ -540,7 +449,7 @@ func Test_ExecProcess_Container_CoreSucceeds_Success(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemExecuteProcessV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
@@ -548,10 +457,9 @@ func Test_ExecProcess_Container_CoreSucceeds_Success(t *testing.T) {
 		hostState: uvm,
 		coreint:   mc,
 	}
-	tb.execProcess(rw, req)
+	resp, err := tb.execProcess(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastExecProcess.ID {
 		t.Fatal("last exec process did not have the same container ID")
 	}
@@ -561,18 +469,17 @@ func Test_ExecProcess_Container_CoreSucceeds_Success(t *testing.T) {
 }
 
 func Test_KillContainer_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemShutdownForcedV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemShutdownForcedV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.killContainer(rw, req)
+	resp, err := tb.killContainer(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_KillContainer_CoreFails_Failure(t *testing.T) {
 	r := newMessageBase()
-	req, rw := setupRequestResponse(t, prot.ComputeSystemShutdownForcedV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemShutdownForcedV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -581,23 +488,21 @@ func Test_KillContainer_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.killContainer(rw, req)
+	resp, err := tb.killContainer(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_KillContainer_CoreSucceeds_Success(t *testing.T) {
 	r := newMessageBase()
-	req, rw := setupRequestResponse(t, prot.ComputeSystemShutdownForcedV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemShutdownForcedV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{hostState: uvm, coreint: mc}
-	tb.killContainer(rw, req)
+	resp, err := tb.killContainer(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r, rw)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastSignalContainer.ID {
 		t.Fatal("last signal container did not have the same container ID")
 	}
@@ -607,18 +512,17 @@ func Test_KillContainer_CoreSucceeds_Success(t *testing.T) {
 }
 
 func Test_ShutdownContainer_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemShutdownGracefulV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemShutdownGracefulV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.shutdownContainer(rw, req)
+	resp, err := tb.shutdownContainer(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_ShutdownContainer_CoreFails_Failure(t *testing.T) {
 	r := newMessageBase()
-	req, rw := setupRequestResponse(t, prot.ComputeSystemShutdownGracefulV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemShutdownGracefulV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -627,23 +531,21 @@ func Test_ShutdownContainer_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.shutdownContainer(rw, req)
+	resp, err := tb.shutdownContainer(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_ShutdownContainer_CoreSucceeds_Success(t *testing.T) {
 	r := newMessageBase()
-	req, rw := setupRequestResponse(t, prot.ComputeSystemShutdownGracefulV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemShutdownGracefulV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{hostState: uvm, coreint: mc}
-	tb.shutdownContainer(rw, req)
+	resp, err := tb.shutdownContainer(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r, rw)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastSignalContainer.ID {
 		t.Fatal("last signal container did not have the same container ID")
 	}
@@ -653,13 +555,12 @@ func Test_ShutdownContainer_CoreSucceeds_Success(t *testing.T) {
 }
 
 func Test_SignalProcess_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemSignalProcessV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemSignalProcessV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.signalProcess(rw, req)
+	resp, err := tb.signalProcess(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_SignalProcess_CoreFails_Failure(t *testing.T) {
@@ -671,7 +572,7 @@ func Test_SignalProcess_CoreFails_Failure(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemSignalProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemSignalProcessV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -680,10 +581,9 @@ func Test_SignalProcess_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.signalProcess(rw, req)
+	resp, err := tb.signalProcess(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_SignalProcess_CoreSucceeds_Success(t *testing.T) {
@@ -695,15 +595,14 @@ func Test_SignalProcess_CoreSucceeds_Success(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemSignalProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemSignalProcessV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{hostState: uvm, coreint: mc}
-	tb.signalProcess(rw, req)
+	resp, err := tb.signalProcess(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if uint32(mc.LastSignalProcess.Pid) != r.ProcessID {
 		t.Fatal("last signal process did not have the same pid")
 	}
@@ -713,13 +612,12 @@ func Test_SignalProcess_CoreSucceeds_Success(t *testing.T) {
 }
 
 func Test_GetProperties_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemGetPropertiesV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemGetPropertiesV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.getProperties(rw, req)
+	resp, err := tb.getProperties(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_GetProperties_CoreFails_Failure(t *testing.T) {
@@ -728,7 +626,7 @@ func Test_GetProperties_CoreFails_Failure(t *testing.T) {
 		Query:       "",
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemGetPropertiesV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemGetPropertiesV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -737,10 +635,9 @@ func Test_GetProperties_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.getProperties(rw, req)
+	resp, err := tb.getProperties(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_GetProperties_CoreSucceeds_Success(t *testing.T) {
@@ -749,25 +646,24 @@ func Test_GetProperties_CoreSucceeds_Success(t *testing.T) {
 		Query:       "{\"PropertyTypes\":[\"ProcessList\"]}",
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemGetPropertiesV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemGetPropertiesV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{hostState: uvm, coreint: mc}
-	tb.getProperties(rw, req)
+	resp, err := tb.getProperties(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if mc.LastGetProperties.ID != r.ContainerID {
 		t.Fatal("last get properties did not have the same container ID")
 	}
-	response, ok := rw.response.(*prot.ContainerGetPropertiesResponse)
+	cgpr, ok := resp.(*prot.ContainerGetPropertiesResponse)
 	if !ok {
-		t.Fatalf("get properties returned the wrong response type: %T", rw.response)
+		t.Fatalf("get properties returned the wrong response type: %T", resp)
 	}
 
 	var properties prot.Properties
-	json.Unmarshal([]byte(response.Properties), &properties)
+	json.Unmarshal([]byte(cgpr.Properties), &properties)
 	numProcesses := len(properties.ProcessList)
 	if numProcesses != 1 {
 		t.Fatalf("get properties returned an incorrect number of processes: %d", numProcesses)
@@ -779,13 +675,12 @@ func Test_GetProperties_CoreSucceeds_Success(t *testing.T) {
 }
 
 func Test_WaitOnProcess_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.waitOnProcess(rw, req)
+	resp, err := tb.waitOnProcess(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_WaitOnProcess_CoreFails_Failure(t *testing.T) {
@@ -795,7 +690,7 @@ func Test_WaitOnProcess_CoreFails_Failure(t *testing.T) {
 		TimeoutInMs: 1000,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -804,10 +699,9 @@ func Test_WaitOnProcess_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.waitOnProcess(rw, req)
+	resp, err := tb.waitOnProcess(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_WaitOnProcess_CoreSucceeds_Timeout_Error(t *testing.T) {
@@ -817,7 +711,7 @@ func Test_WaitOnProcess_CoreSucceeds_Timeout_Error(t *testing.T) {
 		TimeoutInMs: 10,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	mc.LastWaitProcessReturnContext = &mockcore.WaitProcessReturnContext{
@@ -828,10 +722,9 @@ func Test_WaitOnProcess_CoreSucceeds_Timeout_Error(t *testing.T) {
 	// Do not write the exit code so that the timeout occurs.
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{hostState: uvm, coreint: mc}
-	tb.waitOnProcess(rw, req)
+	resp, err := tb.waitOnProcess(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 
 	// Verify that the caller bridge calls done in the timeout case
 	// to acknowledge the response.
@@ -845,7 +738,7 @@ func Test_WaitOnProcess_CoreSucceeds_Success(t *testing.T) {
 		TimeoutInMs: 1000,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemWaitForProcessV1, prot.PvV3, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	mc.LastWaitProcessReturnContext = &mockcore.WaitProcessReturnContext{
@@ -858,9 +751,9 @@ func Test_WaitOnProcess_CoreSucceeds_Success(t *testing.T) {
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{hostState: uvm, coreint: mc}
-	tb.waitOnProcess(rw, req)
+	resp, err := tb.waitOnProcess(req)
 
-	verifyResponseSuccess(t, rw)
+	verifyResponseSuccess(t, resp, err)
 	if uint32(mc.LastWaitProcess.Pid) != r.ProcessID {
 		t.Fatal("last wait process did not have same pid")
 	}
@@ -870,13 +763,12 @@ func Test_WaitOnProcess_CoreSucceeds_Success(t *testing.T) {
 }
 
 func Test_ResizeConsole_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemResizeConsoleV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemResizeConsoleV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.resizeConsole(rw, req)
+	resp, err := tb.resizeConsole(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_ResizeConsole_CoreFails_Failure(t *testing.T) {
@@ -887,7 +779,7 @@ func Test_ResizeConsole_CoreFails_Failure(t *testing.T) {
 		Height:      20,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemResizeConsoleV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemResizeConsoleV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -896,10 +788,9 @@ func Test_ResizeConsole_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.resizeConsole(rw, req)
+	resp, err := tb.resizeConsole(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_ResizeConsole_CoreSucceeds_Success(t *testing.T) {
@@ -910,15 +801,14 @@ func Test_ResizeConsole_CoreSucceeds_Success(t *testing.T) {
 		Height:      480,
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemResizeConsoleV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemResizeConsoleV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{hostState: uvm, coreint: mc}
-	tb.resizeConsole(rw, req)
+	resp, err := tb.resizeConsole(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if uint32(mc.LastResizeConsole.Pid) != r.ProcessID {
 		t.Fatal("last resize console did not have same pid")
 	}
@@ -931,13 +821,12 @@ func Test_ResizeConsole_CoreSucceeds_Success(t *testing.T) {
 }
 
 func Test_ModifySettings_InvalidJson_Failure(t *testing.T) {
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, nil)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, nil)
 
 	tb := new(Bridge)
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityIDEmptyGUID(t, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_ModifySettings_VirtualDisk_InvalidSettingsJson_Failure(t *testing.T) {
@@ -948,13 +837,12 @@ func Test_ModifySettings_VirtualDisk_InvalidSettingsJson_Failure(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
 
 	tb := new(Bridge)
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_ModifySettings_MappedDirectory_InvalidSettingsJson_Failure(t *testing.T) {
@@ -965,13 +853,12 @@ func Test_ModifySettings_MappedDirectory_InvalidSettingsJson_Failure(t *testing.
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
 
 	tb := new(Bridge)
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseJSONError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseJSONError(t, resp, err)
 }
 
 func Test_ModifySettings_CoreFails_Failure(t *testing.T) {
@@ -983,7 +870,7 @@ func Test_ModifySettings_CoreFails_Failure(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
 
 	uvm := hcsv2.NewHost(nil, nil)
 	tb := &Bridge{
@@ -992,10 +879,9 @@ func Test_ModifySettings_CoreFails_Failure(t *testing.T) {
 			Behavior: mockcore.Error,
 		},
 	}
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }
 
 func Test_ModifySettings_CoreSucceeds_Success(t *testing.T) {
@@ -1010,7 +896,7 @@ func Test_ModifySettings_CoreSucceeds_Success(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	uvm := hcsv2.NewHost(nil, nil)
@@ -1018,10 +904,9 @@ func Test_ModifySettings_CoreSucceeds_Success(t *testing.T) {
 		hostState: uvm,
 		coreint:   mc,
 	}
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastModifySettings.ID {
 		t.Fatal("last modify settings did not have the same container ID")
 	}
@@ -1044,16 +929,15 @@ func Test_ModifySettings_V2_Success(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{
 		coreint: mc,
 	}
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastModifySettings.ID {
 		t.Fatal("last modify settings did not have the same container ID")
 	}
@@ -1086,7 +970,7 @@ func Test_ModifySettings_BothV1V2_Success(t *testing.T) {
 		},
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	uvm := hcsv2.NewHost(nil, nil)
@@ -1094,10 +978,9 @@ func Test_ModifySettings_BothV1V2_Success(t *testing.T) {
 		hostState: uvm,
 		coreint:   mc,
 	}
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseSuccess(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseSuccess(t, resp, err)
 	if r.ContainerID != mc.LastModifySettings.ID {
 		t.Fatal("last modify settings did not have the same container ID")
 	}
@@ -1111,14 +994,13 @@ func Test_ModifySettings_NeitherV1V2_Fails(t *testing.T) {
 		MessageBase: newMessageBase(),
 	}
 
-	req, rw := setupRequestResponse(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
+	req := createRequest(t, prot.ComputeSystemModifySettingsV1, prot.PvV3, r)
 
 	mc := &mockcore.MockCore{Behavior: mockcore.Success}
 	tb := &Bridge{
 		coreint: mc,
 	}
-	tb.modifySettings(rw, req)
+	resp, err := tb.modifySettings(req)
 
-	verifyResponseError(t, rw)
-	verifyActivityID(t, r.MessageBase, rw)
+	verifyResponseError(t, resp, err)
 }

--- a/service/gcs/bridge/bridge_unit_test.go
+++ b/service/gcs/bridge/bridge_unit_test.go
@@ -32,11 +32,14 @@ func Test_Bridge_Mux_New_Success(t *testing.T) {
 }
 
 type thandler struct {
-	set bool
+	set  bool
+	resp RequestResponse
+	err  error
 }
 
-func (h *thandler) ServeMsg(w ResponseWriter, r *Request) {
+func (h *thandler) ServeMsg(r *Request) (RequestResponse, error) {
 	h.set = true
+	return h.resp, h.err
 }
 
 func TestBridgeMux_Handle_NilHandler_Panic(t *testing.T) {
@@ -79,7 +82,7 @@ func Test_Bridge_Mux_Handle_Succeeds(t *testing.T) {
 	}
 
 	// Is it the correct handler?
-	hOut.ServeMsg(nil, nil)
+	hOut.ServeMsg(nil)
 
 	if !th.set {
 		t.Error("The handler added was not the same handler.")
@@ -104,7 +107,8 @@ func TestBridgeMux_HandleFunc_NilMap_Panic(t *testing.T) {
 		}
 	}()
 
-	hIn := func(ResponseWriter, *Request) {
+	hIn := func(*Request) (RequestResponse, error) {
+		return nil, nil
 	}
 
 	m := &Mux{} // Caller didn't use NewBridgeMux (not supported).
@@ -113,8 +117,9 @@ func TestBridgeMux_HandleFunc_NilMap_Panic(t *testing.T) {
 
 func Test_Bridge_Mux_HandleFunc_Succeeds(t *testing.T) {
 	var set bool
-	hIn := func(ResponseWriter, *Request) {
+	hIn := func(*Request) (RequestResponse, error) {
 		set = true
+		return nil, nil
 	}
 
 	m := NewBridgeMux()
@@ -132,7 +137,7 @@ func Test_Bridge_Mux_HandleFunc_Succeeds(t *testing.T) {
 	}
 
 	// Is it the correct handler?
-	hOut.ServeMsg(nil, nil)
+	hOut.ServeMsg(nil)
 
 	if !set {
 		t.Error("The handler added was not the same handler.")
@@ -147,8 +152,9 @@ func Test_Bridge_Mux_Handler_NilRequest_Panic(t *testing.T) {
 	}()
 
 	var set bool
-	hIn := func(ResponseWriter, *Request) {
+	hIn := func(*Request) (RequestResponse, error) {
 		set = true
+		return nil, nil
 	}
 
 	m := NewBridgeMux()
@@ -159,23 +165,23 @@ func Test_Bridge_Mux_Handler_NilRequest_Panic(t *testing.T) {
 	}
 }
 
-func verifyResponseIsDefaultHandler(t *testing.T, i interface{}) {
-	if i == nil {
-		t.Error("The response is nil")
-		return
+func verifyResponseIsDefaultHandler(t *testing.T, resp RequestResponse) {
+	if resp == nil {
+		t.Fatal("The response is nil")
 	}
 
-	base := i.(*prot.MessageResponseBase)
+	base := resp.Base()
 	if base.Result != int32(gcserr.HrNotImpl) {
-		t.Error("The default handler did not set a -1 error result.")
+		t.Fatal("The default handler did not set a -1 error result.")
 	}
 	if len(base.ErrorRecords) != 1 {
-		t.Error("The default handler did not set an error record.")
+		t.Fatal("The default handler did not set an error record.")
 	}
 	if !strings.Contains(base.ErrorRecords[0].Message, "bridge: function not supported") {
-		t.Error("The default handler did not return the not supported message")
+		t.Fatal("The default handler did not return the not supported message")
 	}
 }
+
 func Test_Bridge_Mux_Handler_NotAdded_Default(t *testing.T) {
 	// Testing specifically that if we have a bridge with no handlers that
 	// for the incomming request we get the default handler.
@@ -191,16 +197,12 @@ func Test_Bridge_Mux_Handler_NotAdded_Default(t *testing.T) {
 	}
 
 	hOut := m.Handler(req)
-	respChan := make(chan bridgeResponse, 1) // We need to allocate the space because we are running ServeMsg sync.
-	defer close(respChan)
-	respW := &requestResponseWriter{header: req.Header, respChan: respChan}
-	hOut.ServeMsg(respW, req)
-
-	select {
-	case resp := <-respChan:
-		verifyResponseIsDefaultHandler(t, resp.response)
-	default:
-		t.Error("The deafult handler returned no writes.")
+	resp, err := hOut.ServeMsg(req)
+	if resp != nil {
+		t.Fatalf("expected nil response got: %+v", resp)
+	}
+	if err == nil {
+		t.Fatal("expected valid error got: nil")
 	}
 }
 
@@ -227,16 +229,14 @@ func Test_Bridge_Mux_Handler_Added_NotMatched(t *testing.T) {
 	hOut := m.Handler(req)
 	respChan := make(chan bridgeResponse, 1) // We need to allocate the space because we are running ServeMsg sync.
 	defer close(respChan)
-	respW := &requestResponseWriter{header: req.Header, respChan: respChan}
-	hOut.ServeMsg(respW, req)
 
-	select {
-	case resp := <-respChan:
-		verifyResponseIsDefaultHandler(t, resp.response)
-	default:
-		t.Error("The deafult handler returned no writes.")
+	resp, err := hOut.ServeMsg(req)
+	if resp != nil {
+		t.Fatalf("expected nil response got: %+v", resp)
 	}
-
+	if err == nil {
+		t.Fatal("expected valid error got: nil")
+	}
 	if th.set {
 		t.Error("Handler did not call the appropriate handler for a match request")
 	}
@@ -244,7 +244,9 @@ func Test_Bridge_Mux_Handler_Added_NotMatched(t *testing.T) {
 
 func Test_Bridge_Mux_Handler_Success(t *testing.T) {
 	m := NewBridgeMux()
-	th := &thandler{}
+	th := &thandler{
+		resp: &prot.ContainerCreateResponse{},
+	}
 
 	m.Handle(prot.ComputeSystemCreateV1, prot.PvInvalid, th)
 
@@ -259,9 +261,14 @@ func Test_Bridge_Mux_Handler_Success(t *testing.T) {
 	hOut := m.Handler(req)
 	respChan := make(chan bridgeResponse, 1) // We need to allocate the space because we are running ServeMsg sync.
 	defer close(respChan)
-	respW := &requestResponseWriter{header: req.Header, respChan: respChan}
-	hOut.ServeMsg(respW, req)
 
+	resp, err := hOut.ServeMsg(req)
+	if resp == nil {
+		t.Fatal("expected valid response got: nil")
+	}
+	if err != nil {
+		t.Fatalf("expected nil error got: %v", err)
+	}
 	if !th.set {
 		t.Error("Handler did not call the appropriate handler for a match request")
 	}
@@ -283,15 +290,13 @@ func Test_Bridge_Mux_ServeMsg_NotAdded_Default(t *testing.T) {
 
 	respChan := make(chan bridgeResponse, 1) // We need to allocate the space because we are running ServeMsg sync.
 	defer close(respChan)
-	respW := &requestResponseWriter{header: req.Header, respChan: respChan}
 
-	m.ServeMsg(respW, req)
-
-	select {
-	case resp := <-respChan:
-		verifyResponseIsDefaultHandler(t, resp.response)
-	default:
-		t.Error("The deafult handler returned no writes.")
+	resp, err := m.ServeMsg(req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got: %+v", resp)
+	}
+	if err == nil {
+		t.Fatal("expected error got: nil")
 	}
 }
 
@@ -317,17 +322,14 @@ func Test_Bridge_Mux_ServeMsg_Added_NotMatched(t *testing.T) {
 	// Handle the request of a different type.
 	respChan := make(chan bridgeResponse, 1) // We need to allocate the space because we are running ServeMsg sync.
 	defer close(respChan)
-	respW := &requestResponseWriter{header: req.Header, respChan: respChan}
 
-	m.ServeMsg(respW, req)
-
-	select {
-	case resp := <-respChan:
-		verifyResponseIsDefaultHandler(t, resp.response)
-	default:
-		t.Error("The deafult handler returned no writes.")
+	resp, err := m.ServeMsg(req)
+	if resp != nil {
+		t.Fatalf("expected nil response, got: %+v", resp)
 	}
-
+	if err == nil {
+		t.Fatal("expected error got: nil")
+	}
 	if th.set {
 		t.Error("Handler did not call the appropriate handler for a match request")
 	}
@@ -335,7 +337,9 @@ func Test_Bridge_Mux_ServeMsg_Added_NotMatched(t *testing.T) {
 
 func Test_Bridge_Mux_ServeMsg_Success(t *testing.T) {
 	m := NewBridgeMux()
-	th := &thandler{}
+	th := &thandler{
+		resp: &prot.ContainerCreateResponse{},
+	}
 
 	m.Handle(prot.ComputeSystemCreateV1, prot.PvInvalid, th)
 
@@ -349,9 +353,14 @@ func Test_Bridge_Mux_ServeMsg_Success(t *testing.T) {
 
 	respChan := make(chan bridgeResponse, 1) // We need to allocate the space because we are running ServeMsg sync.
 	defer close(respChan)
-	respW := &requestResponseWriter{header: req.Header, respChan: respChan}
-	m.ServeMsg(respW, req)
 
+	resp, err := m.ServeMsg(req)
+	if resp == nil {
+		t.Fatal("expected valid response got: nil")
+	}
+	if err != nil {
+		t.Fatalf("expected nil error got: %v", err)
+	}
 	if !th.set {
 		t.Error("Handler did not call the appropriate handler for a match request")
 	}
@@ -490,6 +499,9 @@ func Test_Bridge_ListenAndServe_UnknownMessageHandler_Success(t *testing.T) {
 		t.Error("Response header had wrong sequence id")
 	}
 	verifyResponseIsDefaultHandler(t, response)
+	if response.ActivityID != message.ActivityID {
+		t.Fatal("Response had invalid activity id")
+	}
 }
 
 func Test_Bridge_ListenAndServe_CorrectHandler_Success(t *testing.T) {
@@ -506,33 +518,28 @@ func Test_Bridge_ListenAndServe_CorrectHandler_Success(t *testing.T) {
 			ActivityID:  "00000000-0000-0000-0000-000000000010",
 		},
 	}
-	resizeFn := func(w ResponseWriter, r *Request) {
+	resizeFn := func(r *Request) (RequestResponse, error) {
 		// Verify the request is as expected.
 		if r.Header.Type != prot.ComputeSystemResizeConsoleV1 {
-			w.Error("", errors.New("bridge_test: wrong request type"))
-			return
+			return nil, errors.New("bridge_test: wrong request type")
 		}
 		if r.Header.ID != prot.SequenceID(1) {
-			w.Error("", errors.New("bridge_test: wrong sequence id"))
-			return
+			return nil, errors.New("bridge_test: wrong sequence id")
 		}
 
 		rBody := prot.ContainerResizeConsole{}
 
 		if err := json.Unmarshal(r.Message, &rBody); err != nil {
-			w.Error("", errors.New("failed to unmarshal body"))
-			return
+			return nil, errors.New("failed to unmarshal body")
 		}
 		if message.ContainerID != rBody.ContainerID {
-			w.Error("", errors.New("containerID of source and handler func not equal"))
-			return
+			return nil, errors.New("containerID of source and handler func not equal")
 		}
 
-		response := &prot.MessageResponseBase{
+		return &prot.MessageResponseBase{
 			Result:     1,
 			ActivityID: rBody.ActivityID,
-		}
-		w.Write(response)
+		}, nil
 	}
 	mux.HandleFunc(prot.ComputeSystemResizeConsoleV1, prot.PvV3, resizeFn)
 	b := &Bridge{
@@ -590,21 +597,18 @@ func Test_Bridge_ListenAndServe_HandlersAreAsync_Success(t *testing.T) {
 	orderWg := sync.WaitGroup{}
 	orderWg.Add(1)
 
-	firstFn := func(w ResponseWriter, r *Request) {
+	firstFn := func(r *Request) (RequestResponse, error) {
 		// Wait for the second request to come in.
 		orderWg.Wait()
-		response := &prot.MessageResponseBase{
+		return &prot.MessageResponseBase{
 			Result: 1,
-		}
-		w.Write(response)
+		}, nil
 	}
-	secondFn := func(w ResponseWriter, r *Request) {
-		response := &prot.MessageResponseBase{
+	secondFn := func(r *Request) (RequestResponse, error) {
+		defer orderWg.Done()
+		return &prot.MessageResponseBase{
 			Result: 10,
-		}
-		w.Write(response)
-		// Allow the first to proceed.
-		orderWg.Done()
+		}, nil
 	}
 	mux.HandleFunc(prot.ComputeSystemResizeConsoleV1, prot.PvV3, firstFn)
 	mux.HandleFunc(prot.ComputeSystemModifySettingsV1, prot.PvV3, secondFn)

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -641,16 +641,21 @@ type ErrorRecord struct {
 // GCS to the HCS except for ContainerNotification.
 type MessageResponseBase struct {
 	Result       int32
-	ActivityID   string        `json:"ActivityId"`
+	ActivityID   string        `json:"ActivityId,omitempty"`
 	ErrorMessage string        `json:",omitempty"` // Only used by hcsshim external bridge
 	ErrorRecords []ErrorRecord `json:",omitempty"`
+}
+
+// Base returns the response base by reference.
+func (mrp *MessageResponseBase) Base() *MessageResponseBase {
+	return mrp
 }
 
 // NegotiateProtocolResponse is the message to the HCS responding to a
 // NegotiateProtocol message. It specifies the prefered protocol version and
 // available capabilities of the GCS.
 type NegotiateProtocolResponse struct {
-	*MessageResponseBase
+	MessageResponseBase
 	Version      uint32
 	Capabilities GcsCapabilities
 }
@@ -660,7 +665,7 @@ type NegotiateProtocolResponse struct {
 // for protocol versions 3 and lower, returning protocol version information to
 // the HCS.
 type ContainerCreateResponse struct {
-	*MessageResponseBase
+	MessageResponseBase
 	SelectedVersion         string `json:",omitempty"`
 	SelectedProtocolVersion uint32
 }
@@ -668,14 +673,14 @@ type ContainerCreateResponse struct {
 // ContainerExecuteProcessResponse is the message to the HCS responding to a
 // ContainerExecuteProcess message. It provides back the process's pid.
 type ContainerExecuteProcessResponse struct {
-	*MessageResponseBase
+	MessageResponseBase
 	ProcessID uint32 `json:"ProcessId"`
 }
 
 // ContainerWaitForProcessResponse is the message to the HCS responding to a
 // ContainerWaitForProcess message. It is only sent when the process has exited.
 type ContainerWaitForProcessResponse struct {
-	*MessageResponseBase
+	MessageResponseBase
 	ExitCode uint32
 }
 
@@ -683,7 +688,7 @@ type ContainerWaitForProcessResponse struct {
 // ContainerGetProperties message. It contains a string representing the
 // properties requested.
 type ContainerGetPropertiesResponse struct {
-	*MessageResponseBase
+	MessageResponseBase
 	Properties string
 }
 


### PR DESCRIPTION
This change makes it easier for the rquest/response pattern to return a result
or error. This is perferred over the w.Write and w.Error pattern where a
response must be written and then an early return. This makes the code easier
to read and control flow easier to understand.