### PR TITLE
Maps /etc/hosts and /etc/hostname to sandbox/workload containers

### DIFF
--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -1,0 +1,119 @@
+// +build linux
+
+package network
+
+import (
+	"context"
+	"testing"
+)
+
+func Test_GenerateResolvConfContent(t *testing.T) {
+	type testcase struct {
+		name string
+
+		searches []string
+		servers  []string
+		options  []string
+
+		expectedContent string
+		expectErr       bool
+	}
+	testcases := []*testcase{
+		{
+			name: "Empty",
+		},
+		{
+			name:      "MaxSearches",
+			searches:  []string{"1", "2", "3", "4", "5", "6", "7"},
+			expectErr: true,
+		},
+		{
+			name:            "ValidSearches",
+			searches:        []string{"a.com", "b.com"},
+			expectedContent: "search a.com b.com\n",
+		},
+		{
+			name:            "ValidServers",
+			servers:         []string{"8.8.8.8", "8.8.4.4"},
+			expectedContent: "nameserver 8.8.8.8\nnameserver 8.8.4.4\n",
+		},
+		{
+			name:            "ValidOptions",
+			options:         []string{"timeout:30", "inet6"},
+			expectedContent: "options timeout:30 inet6\n",
+		},
+		{
+			name:            "All",
+			searches:        []string{"a.com", "b.com"},
+			servers:         []string{"8.8.8.8", "8.8.4.4"},
+			options:         []string{"timeout:30", "inet6"},
+			expectedContent: "search a.com b.com\nnameserver 8.8.8.8\nnameserver 8.8.4.4\noptions timeout:30 inet6\n",
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, err := GenerateResolvConfContent(context.Background(), tc.searches, tc.servers, tc.options)
+			if tc.expectErr && err == nil {
+				t.Fatal("expected err got nil")
+			} else if !tc.expectErr && err != nil {
+				t.Fatalf("expected no error got %v:", err)
+			}
+
+			if c != tc.expectedContent {
+				t.Fatalf("expected content: %q got: %q", tc.expectedContent, c)
+			}
+		})
+	}
+}
+
+func Test_MergeValues(t *testing.T) {
+	type testcase struct {
+		name string
+
+		first  []string
+		second []string
+
+		expected []string
+	}
+	testcases := []*testcase{
+		{
+			name: "BothEmpty",
+		},
+		{
+			name:     "FirstEmpty",
+			second:   []string{"a", "b"},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "SecondEmpty",
+			first:    []string{"a", "b"},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "AllUnique",
+			first:    []string{"a", "c", "d"},
+			second:   []string{"b", "e"},
+			expected: []string{"a", "c", "d", "b", "e"},
+		},
+		{
+			name:     "NonUnique",
+			first:    []string{"a", "c", "d"},
+			second:   []string{"a", "b", "c", "d"},
+			expected: []string{"a", "c", "d", "b"},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := MergeValues(tc.first, tc.second)
+			if len(m) != len(tc.expected) {
+				t.Fatalf("expected %d entries got: %d", len(tc.expected), len(m))
+			}
+			for i := 0; i < len(tc.expected); i++ {
+				if tc.expected[i] != m[i] {
+					t.Logf("%v :: %v", tc.expected, m)
+					t.Fatalf("expected value: %q at index: %d got: %q", tc.expected[i], i, m[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/runtime/hcsv2/network.go
+++ b/internal/runtime/hcsv2/network.go
@@ -1,0 +1,274 @@
+package hcsv2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/Microsoft/opengcs/internal/network"
+	"github.com/Microsoft/opengcs/service/gcs/gcserr"
+	"github.com/Microsoft/opengcs/service/gcs/prot"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// namespaceSync protects access to `namespaces`.
+	namespaceSync sync.Mutex
+	// namespaces is the set of `in-memory` namespace adapters know to the GCS.
+	// These may or may not be assigned to a container as there is support for
+	// pre-Add and post-Add.
+	namespaces map[string]*namespace
+
+	networkInstanceIDToName = network.InstanceIDToName
+)
+
+func init() {
+	namespaces = make(map[string]*namespace)
+}
+
+// getNetworkNamespace returns the namespace found by `id`. If the namespace
+// does not exist returns `gcserr.HrErrNotFound`.
+func getNetworkNamespace(id string) (*namespace, error) {
+	id = strings.ToLower(id)
+
+	namespaceSync.Lock()
+	defer namespaceSync.Unlock()
+
+	ns, ok := namespaces[id]
+	if !ok {
+		return nil, gcserr.WrapHresult(errors.Errorf("namespace '%s' not found", id), gcserr.HrErrNotFound)
+	}
+	return ns, nil
+}
+
+// getOrAddNetworkNamespace returns the namespace found by `id` or creates a new
+// one and assigns `id.
+func getOrAddNetworkNamespace(id string) *namespace {
+	id = strings.ToLower(id)
+
+	namespaceSync.Lock()
+	defer namespaceSync.Unlock()
+
+	ns, ok := namespaces[id]
+	if !ok {
+		ns = &namespace{
+			id: id,
+		}
+		namespaces[id] = ns
+	}
+	return ns
+}
+
+// removeNetworkNamespace removes the in-memory `namespace` found by `id`.
+func removeNetworkNamespace(ctx context.Context, id string) error {
+	id = strings.ToLower(id)
+
+	op := "hcsv2::removeNetworkNamespace"
+	log := logrus.WithField("namespace", id)
+	log.Info(op + " - Begin Operation")
+	defer log.Info(op + " - End Operation")
+
+	namespaceSync.Lock()
+	defer namespaceSync.Unlock()
+
+	ns, ok := namespaces[id]
+	if ok {
+		ns.m.Lock()
+		defer ns.m.Unlock()
+		if len(ns.nics) > 0 {
+			return errors.Errorf("network namespace '%s' contains adapters", id)
+		}
+		delete(namespaces, id)
+	}
+
+	return nil
+}
+
+// namespace struct maps all vNIC's to the namespace ID used by the HNS.
+type namespace struct {
+	id string
+
+	m    sync.Mutex
+	pid  int
+	nics []*nicInNamespace
+}
+
+// ID is the id of the network namespace
+func (n *namespace) ID() string {
+	return n.id
+}
+
+// AssignContainerPid assigns `pid` to `n` but does NOT move any previously
+// assigned adapters into this namespace. The caller MUST call `Sync()` to
+// complete this operation.
+func (n *namespace) AssignContainerPid(ctx context.Context, pid int) error {
+	op := "namespace::AssignContainerPid"
+	log := logrus.WithFields(logrus.Fields{
+		"namespace": n.id,
+		"pid":       pid,
+	})
+	log.Info(op + " - Begin Operation")
+	defer log.Info(op + " - End Operation")
+
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	if n.pid != 0 {
+		return errors.Errorf("previously assigned container pid: %d", n.pid)
+	}
+
+	n.pid = pid
+	return nil
+}
+
+// Adapters returns a copy of the adapters assigned to `n` at the time of the
+// call.
+func (n *namespace) Adapters() []*prot.NetworkAdapterV2 {
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	adps := make([]*prot.NetworkAdapterV2, len(n.nics))
+	for i, nin := range n.nics {
+		adps[i] = nin.adapter
+	}
+	return adps
+}
+
+// AddAdapter adds `adp` to `n` but does NOT move the adapter into the network
+// namespace assigned to `n`. A user must call `Sync()` to complete this
+// operation.
+func (n *namespace) AddAdapter(ctx context.Context, adp *prot.NetworkAdapterV2) error {
+	op := "namespace::AddAdapter"
+	log := logrus.WithFields(logrus.Fields{
+		"namespace": n.id,
+		"adapter":   fmt.Sprintf("%+v", adp),
+	})
+	log.Info(op + " - Begin Operation")
+	defer log.Info(op + " - End Operation")
+
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	for _, nic := range n.nics {
+		if strings.EqualFold(nic.adapter.ID, adp.ID) {
+			return errors.Errorf("adapter with id: '%s' already present in namespace", adp.ID)
+		}
+	}
+
+	ifname, err := networkInstanceIDToName(adp.ID, true)
+	if err != nil {
+		return err
+	}
+	n.nics = append(n.nics, &nicInNamespace{
+		adapter: adp,
+		ifname:  ifname,
+	})
+	return nil
+}
+
+// RemoveAdapter removes the adapter matching `id` from `n`. If `id` is not
+// found returns no error.
+func (n *namespace) RemoveAdapter(ctx context.Context, id string) error {
+	op := "namespace::RemoveAdapter"
+	log := logrus.WithFields(logrus.Fields{
+		"namespace":  n.id,
+		"adapter-id": id,
+	})
+	log.Info(op + " - Begin Operation")
+	defer log.Info(op + " - End Operation")
+
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	// TODO: do we need to remove anything guestside from a sandbox namespace?
+
+	i := -1
+	for j, nic := range n.nics {
+		if strings.EqualFold(nic.adapter.ID, id) {
+			i = j
+			break
+		}
+	}
+	if i > -1 {
+		n.nics = append(n.nics[:i], n.nics[i+1:]...)
+	}
+	return nil
+}
+
+// Sync moves all adapters to the network namespace of `n` if assigned.
+func (n *namespace) Sync(ctx context.Context) error {
+	op := "namespace::Sync"
+	log := logrus.WithFields(logrus.Fields{
+		"namespace": n.id,
+	})
+	log.Info(op + " - Begin Operation")
+	defer log.Info(op + " - End Operation")
+
+	n.m.Lock()
+	defer n.m.Unlock()
+
+	if n.pid != 0 {
+		for _, a := range n.nics {
+			err := a.assignToPid(ctx, n.pid)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// nicInNamespace represents a single network adapter that has been added to the
+// guest and its mapping to the linux `ifname`.
+type nicInNamespace struct {
+	// adapter captures the network settings when the nic was added
+	adapter *prot.NetworkAdapterV2
+	// ifname is the interface name resolved for this adapter
+	ifname string
+	// assignedPid will be `0` for any nic in this namespace that has not been
+	// moved into a specific pid network namespace.
+	assignedPid int
+}
+
+// assignToPid assigns `nin.adapter`, represented by `nin.ifname` to `pid`.
+func (nin *nicInNamespace) assignToPid(ctx context.Context, pid int) error {
+	op := "nicInNamespace::assignToPid"
+	log := logrus.WithFields(logrus.Fields{
+		"adapter": fmt.Sprintf("%+v", nin.adapter),
+		"ifname":  nin.ifname,
+		"pid":     pid,
+	})
+	log.Info(op + " - Begin Operation")
+	defer log.Info(op + " - End Operation")
+
+	// TODO: netnscfg is not coded for v2 but since they are almost the same
+	// just convert the parts of the adapter here.
+	v1Adapter := &prot.NetworkAdapter{
+		NatEnabled:         nin.adapter.IPAddress != "",
+		AllocatedIPAddress: nin.adapter.IPAddress,
+		HostIPAddress:      nin.adapter.GatewayAddress,
+		HostIPPrefixLength: nin.adapter.PrefixLength,
+		EnableLowMetric:    nin.adapter.EnableLowMetric,
+		EncapOverhead:      nin.adapter.EncapOverhead,
+	}
+
+	cfg, err := json.Marshal(v1Adapter)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal adapter struct to JSON")
+	}
+
+	out, err := exec.Command("netnscfg",
+		"-if", nin.ifname,
+		"-nspid", strconv.Itoa(pid),
+		"-cfg", string(cfg)).CombinedOutput()
+	if err != nil {
+		return errors.Wrapf(err, "failed to configure adapter aid: %s, if id: %s %s", nin.adapter.ID, nin.ifname, string(out))
+	}
+	nin.assignedPid = pid
+	return nil
+}

--- a/internal/runtime/hcsv2/network_test.go
+++ b/internal/runtime/hcsv2/network_test.go
@@ -1,0 +1,119 @@
+// +build linux
+
+package hcsv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Microsoft/opengcs/service/gcs/prot"
+)
+
+func Test_getNetworkNamespace_NotExist(t *testing.T) {
+	defer func() {
+		err := removeNetworkNamespace(context.TODO(), t.Name())
+		if err != nil {
+			t.Errorf("failed to remove ns with error: %v", err)
+		}
+	}()
+
+	ns, err := getNetworkNamespace(t.Name())
+	if err == nil {
+		t.Fatal("expected error got nil")
+	}
+	if ns != nil {
+		t.Fatalf("namespace should be nil, got: %+v", ns)
+	}
+}
+
+func Test_getNetworkNamespace_PreviousExist(t *testing.T) {
+	defer func() {
+		err := removeNetworkNamespace(context.TODO(), t.Name())
+		if err != nil {
+			t.Errorf("failed to remove ns with error: %v", err)
+		}
+	}()
+
+	ns1 := getOrAddNetworkNamespace(t.Name())
+	if ns1 == nil {
+		t.Fatal("namespace ns1 should not be nil")
+	}
+	ns2, err := getNetworkNamespace(t.Name())
+	if err != nil {
+		t.Fatalf("expected nil error got: %v", err)
+	}
+	if ns1 != ns2 {
+		t.Fatalf("ns1 %+v != ns2 %+v", ns1, ns2)
+	}
+}
+
+func Test_getOrAddNetworkNamespace_NotExist(t *testing.T) {
+	defer func() {
+		err := removeNetworkNamespace(context.TODO(), t.Name())
+		if err != nil {
+			t.Errorf("failed to remove ns with error: %v", err)
+		}
+	}()
+
+	ns := getOrAddNetworkNamespace(t.Name())
+	if ns == nil {
+		t.Fatalf("namespace should not be nil")
+	}
+}
+
+func Test_getOrAddNetworkNamespace_PreviousExist(t *testing.T) {
+	defer func() {
+		err := removeNetworkNamespace(context.TODO(), t.Name())
+		if err != nil {
+			t.Errorf("failed to remove ns with error: %v", err)
+		}
+	}()
+
+	ns1 := getOrAddNetworkNamespace(t.Name())
+	ns2 := getOrAddNetworkNamespace(t.Name())
+	if ns1 != ns2 {
+		t.Fatalf("ns1 %+v != ns2 %+v", ns1, ns2)
+	}
+}
+
+func Test_removeNetworkNamespace_NotExist(t *testing.T) {
+	err := removeNetworkNamespace(context.TODO(), t.Name())
+	if err != nil {
+		t.Fatalf("failed to remove non-existing ns with error: %v", err)
+	}
+}
+
+func Test_removeNetworkNamespace_HasAdapters(t *testing.T) {
+	defer func() {
+		err := removeNetworkNamespace(context.TODO(), t.Name())
+		if err != nil {
+			t.Errorf("failed to remove ns with error: %v", err)
+		}
+	}()
+	nsOld := networkInstanceIDToName
+	defer func() {
+		networkInstanceIDToName = nsOld
+	}()
+
+	ns := getOrAddNetworkNamespace(t.Name())
+
+	networkInstanceIDToName = func(id string, wait bool) (string, error) {
+		return "/dev/sdz", nil
+	}
+	err := ns.AddAdapter(context.TODO(), &prot.NetworkAdapterV2{ID: "test"})
+	if err != nil {
+		t.Fatalf("failed to add adapter: %v", err)
+	}
+	err = removeNetworkNamespace(context.TODO(), t.Name())
+	if err == nil {
+		t.Fatal("should have failed to delete namespace with adapters")
+	}
+	err = ns.RemoveAdapter(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("failed to remove adapter: %v", err)
+	}
+	err = removeNetworkNamespace(context.TODO(), t.Name())
+	if err != nil {
+		t.Fatalf("should not have failed to delete empty namepace got: %v", err)
+	}
+}

--- a/internal/runtime/hcsv2/sandbox_container.go
+++ b/internal/runtime/hcsv2/sandbox_container.go
@@ -1,0 +1,107 @@
+package hcsv2
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/Microsoft/opengcs/internal/network"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func getSandboxRootDir(id string) string {
+	return filepath.Join("/tmp/gcs/cri", id)
+}
+
+func getSandboxHostnamePath(id string) string {
+	return filepath.Join(getSandboxRootDir(id), "hostname")
+}
+
+func getSandboxHostsPath(id string) string {
+	return filepath.Join(getSandboxRootDir(id), "hosts")
+}
+
+func getSandboxResolvPath(id string) string {
+	return filepath.Join(getSandboxRootDir(id), "resolv.conf")
+}
+
+func setupSandboxContainerSpec(ctx context.Context, id string, spec *oci.Spec) (err error) {
+	// TODO: JTERRY75 use ctx for log
+	operation := "setupSandboxContainerSpec"
+	start := time.Now()
+	defer func() {
+		end := time.Now()
+		fields := logrus.Fields{
+			"cid":       id,
+			"startTime": start,
+			"endTime":   end,
+			"duration":  end.Sub(start),
+		}
+		if err != nil {
+			fields[logrus.ErrorKey] = err
+			logrus.WithFields(fields).Error(operation)
+		} else {
+			logrus.WithFields(fields).Info(operation)
+		}
+	}()
+
+	// Generate the sandbox root dir
+	rootDir := getSandboxRootDir(id)
+	if err := os.MkdirAll(rootDir, 0755); err != nil {
+		return errors.Wrapf(err, "failed to create sandbox root directory %q", rootDir)
+	}
+
+	// Write the hostname
+	hostname := spec.Hostname
+	if hostname == "" {
+		var err error
+		hostname, err = os.Hostname()
+		if err != nil {
+			return errors.Wrap(err, "failed to get hostname")
+		}
+	}
+
+	sandboxHostnamePath := getSandboxHostnamePath(id)
+	if err := ioutil.WriteFile(sandboxHostnamePath, []byte(hostname+"\n"), 0644); err != nil {
+		return errors.Wrapf(err, "failed to write hostname to %q", sandboxHostnamePath)
+	}
+
+	// Write the hosts
+	sandboxHostsPath := getSandboxHostsPath(id)
+	if err := copyFile("/etc/hosts", sandboxHostsPath, 0644); err != nil {
+		return errors.Wrapf(err, "failed to write sandbox hosts to %q", sandboxHostsPath)
+	}
+
+	// Write resolv.conf
+	ns, err := getNetworkNamespace(getNetworkNamespaceID(spec))
+	if err != nil {
+		return err
+	}
+	var searches, servers []string
+	for _, n := range ns.Adapters() {
+		searches = network.MergeValues(searches, strings.Split(n.DNSSuffix, ","))
+		servers = network.MergeValues(servers, strings.Split(n.DNSServerList, ","))
+	}
+	resolvContent, err := network.GenerateResolvConfContent(ctx, searches, servers, nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to generate sandbox resolv.conf content")
+	}
+	sandboxResolvPath := getSandboxResolvPath(id)
+	if err := ioutil.WriteFile(sandboxResolvPath, []byte(resolvContent), 0644); err != nil {
+		return errors.Wrap(err, "failed to write sandbox resolv.conf")
+	}
+
+	// TODO: JTERRY75 /dev/shm is not properly setup for LCOW I believe. CRI
+	// also has a concept of a sandbox/shm file when the IPC NamespaceMode !=
+	// NODE.
+
+	// Clear the windows section as we dont want to forward to runc
+	spec.Windows = nil
+
+	return nil
+}

--- a/internal/runtime/hcsv2/spec.go
+++ b/internal/runtime/hcsv2/spec.go
@@ -1,0 +1,36 @@
+package hcsv2
+
+import (
+	"strings"
+
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// getNetworkNamespaceID returns the `ToLower` of
+// `spec.Windows.Network.NetworkNamespace` or `""`.
+func getNetworkNamespaceID(spec *oci.Spec) string {
+	if spec.Windows != nil &&
+		spec.Windows.Network != nil {
+		return strings.ToLower(spec.Windows.Network.NetworkNamespace)
+	}
+	return ""
+}
+
+// isRootReadonly returns `true` if the spec specifies the rootfs is readonly.
+func isRootReadonly(spec *oci.Spec) bool {
+	if spec.Root != nil {
+		return spec.Root.Readonly
+	}
+	return false
+}
+
+// isInMounts returns `true` if `target` matches a `Destination` in any of
+// `mounts`.
+func isInMounts(target string, mounts []oci.Mount) bool {
+	for _, m := range mounts {
+		if m.Destination == target {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runtime/hcsv2/util.go
+++ b/internal/runtime/hcsv2/util.go
@@ -1,0 +1,30 @@
+// +build linux
+
+package hcsv2
+
+import (
+	"io"
+	"os"
+)
+
+// copyFile copies `src` to `dest` and sets `perm` on `dest`.
+func copyFile(src, dest string, perm os.FileMode) (err error) {
+	s, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	d, err := os.OpenFile(dest, os.O_WRONLY|os.O_CREATE, perm)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			os.Remove(dest)
+		}
+	}()
+	_, err = io.Copy(d, s)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/runtime/hcsv2/uvm.go
+++ b/internal/runtime/hcsv2/uvm.go
@@ -4,16 +4,14 @@ package hcsv2
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"syscall"
 
-	"github.com/Microsoft/opengcs/internal/network"
 	"github.com/Microsoft/opengcs/internal/storage"
 	"github.com/Microsoft/opengcs/internal/storage/overlay"
 	"github.com/Microsoft/opengcs/internal/storage/plan9"
@@ -23,10 +21,7 @@ import (
 	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"github.com/Microsoft/opengcs/service/gcs/runtime"
 	"github.com/Microsoft/opengcs/service/gcs/transport"
-	"github.com/opencontainers/runc/libcontainer/devices"
-	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 // UVMContainerID is the ContainerID that will be sent on any prot.MessageBase
@@ -42,21 +37,13 @@ type Host struct {
 	// Rtime is the Runtime interface used by the GCS core.
 	rtime runtime.Runtime
 	vsock transport.Transport
-
-	// netNamespaces maps `NamespaceID` to the namespace opts
-	netNamespaces map[string]*netNSOpts
-	// networkNSToContainer is a map from `NamespaceID` to sandbox
-	// `ContainerID`. If the map entry does not exist then the adapter is cached
-	// in `netNamespaces` for addition when the sandbox is eventually created.
-	networkNSToContainer sync.Map
 }
 
 func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 	return &Host{
-		containers:    make(map[string]*Container),
-		rtime:         rtime,
-		vsock:         vsock,
-		netNamespaces: make(map[string]*netNSOpts),
+		containers: make(map[string]*Container),
+		rtime:      rtime,
+		vsock:      vsock,
 	}
 }
 
@@ -75,11 +62,6 @@ func (h *Host) GetContainer(id string) (*Container, error) {
 	return h.getContainerLocked(id)
 }
 
-type netNSOpts struct {
-	Adapters   []*prot.NetworkAdapterV2
-	ResolvPath string
-}
-
 func (h *Host) CreateContainer(id string, settings *prot.VMHostedContainerSettingsV2) (*Container, error) {
 	h.containersMutex.Lock()
 	defer h.containersMutex.Unlock()
@@ -88,124 +70,50 @@ func (h *Host) CreateContainer(id string, settings *prot.VMHostedContainerSettin
 		return nil, gcserr.NewHresultError(gcserr.HrVmcomputeSystemAlreadyExists)
 	}
 
-	isSandboxOrStandalone := false
-	if criType, ok := settings.OCISpecification.Annotations["io.kubernetes.cri.container-type"]; ok {
-		// If the annotation is present it must be "sandbox"
-		isSandboxOrStandalone = criType == "sandbox"
+	var (
+		namespaceID string
+		err         error
+	)
+	criType, isCRI := settings.OCISpecification.Annotations["io.kubernetes.cri.container-type"]
+	if isCRI {
+		switch criType {
+		case "sandbox":
+			// Capture namespaceID if any because setupSandboxContainerSpec clears the Windows section.
+			namespaceID = getNetworkNamespaceID(settings.OCISpecification)
+			err = setupSandboxContainerSpec(context.TODO(), id, settings.OCISpecification)
+			defer func() {
+				if err != nil {
+					defer os.RemoveAll(getSandboxRootDir(id))
+				}
+			}()
+		case "container":
+			sid, ok := settings.OCISpecification.Annotations["io.kubernetes.cri.sandbox-id"]
+			if !ok || sid == "" {
+				return nil, errors.Errorf("unsupported 'io.kubernetes.cri.sandbox-id': '%s'", sid)
+			}
+			err = setupWorkloadContainerSpec(context.TODO(), sid, id, settings.OCISpecification)
+			defer func() {
+				if err != nil {
+					defer os.RemoveAll(getWorkloadRootDir(sid, id))
+				}
+			}()
+		default:
+			err = errors.Errorf("unsupported 'io.kubernetes.cri.container-type': '%s'", criType)
+		}
 	} else {
-		// No annotation declares a standalone LCOW
-		isSandboxOrStandalone = true
+		// Capture namespaceID if any because setupStandaloneContainerSpec clears the Windows section.
+		namespaceID = getNetworkNamespaceID(settings.OCISpecification)
+		err = setupStandaloneContainerSpec(context.TODO(), id, settings.OCISpecification)
+		defer func() {
+			if err != nil {
+				os.RemoveAll(getStandaloneRootDir(id))
+			}
+		}()
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	// Check if we have a network namespace and if so generate the resolv.conf
-	// so we can bindmount it into the container
-	var networkNamespace string
-	if settings.OCISpecification.Windows != nil &&
-		settings.OCISpecification.Windows.Network != nil &&
-		settings.OCISpecification.Windows.Network.NetworkNamespace != "" {
-		networkNamespace = strings.ToLower(settings.OCISpecification.Windows.Network.NetworkNamespace)
-	}
-	if networkNamespace != "" {
-		if isSandboxOrStandalone {
-			// We have a network namespace. Generate the resolv.conf and add the bind mount.
-			netopts := h.netNamespaces[networkNamespace]
-			if netopts == nil || len(netopts.Adapters) == 0 {
-				logrus.WithFields(logrus.Fields{
-					"cid":   id,
-					"netNS": networkNamespace,
-				}).Warn("opengcs::CreateContainer - No adapters in namespace for sandbox")
-			} else {
-				logrus.WithFields(logrus.Fields{
-					"cid":   id,
-					"netNS": networkNamespace,
-				}).Info("opengcs::CreateContainer - Generate sandbox resolv.conf")
-
-				// TODO: Can we ever have more than one nic here at start?
-				td, err := ioutil.TempDir("", "")
-				if err != nil {
-					return nil, errors.Wrap(err, "failed to create tmp directory")
-				}
-				resolvPath := filepath.Join(td, "resolv.conf")
-				adp := netopts.Adapters[0]
-				err = network.GenerateResolvConfFile(resolvPath, adp.DNSServerList, adp.DNSSuffix)
-				if err != nil {
-					return nil, err
-				}
-				// Store the resolve path for all workload containers
-				netopts.ResolvPath = resolvPath
-			}
-		}
-		if netopts, ok := h.netNamespaces[networkNamespace]; ok && netopts.ResolvPath != "" {
-			logrus.WithFields(logrus.Fields{
-				"cid":        id,
-				"netNS":      networkNamespace,
-				"resolvPath": netopts.ResolvPath,
-			}).Info("opengcs::CreateContainer - Adding /etc/resolv.conf mount")
-
-			settings.OCISpecification.Mounts = append(settings.OCISpecification.Mounts, oci.Mount{
-				Destination: "/etc/resolv.conf",
-				Type:        "bind",
-				Source:      netopts.ResolvPath,
-				Options:     []string{"bind", "ro"},
-			})
-		}
-	}
-
-	// Clear the windows section of the config
-	settings.OCISpecification.Windows = nil
-
-	// Check if we need to do any capability/device mappings
-	if settings.OCISpecification.Annotations["io.microsoft.virtualmachine.lcow.privileged"] == "true" {
-		logrus.WithFields(logrus.Fields{
-			"cid": id,
-		}).Debugf("opengcs::CreateContainer - 'io.microsoft.virtualmachine.lcow.privileged' set for privileged container")
-
-		// Add all host devices
-		hostDevices, err := devices.HostDevices()
-		if err != nil {
-			return nil, err
-		}
-		for _, hostDevice := range hostDevices {
-			rd := oci.LinuxDevice{
-				Path:  hostDevice.Path,
-				Type:  string(hostDevice.Type),
-				Major: hostDevice.Major,
-				Minor: hostDevice.Minor,
-				UID:   &hostDevice.Uid,
-				GID:   &hostDevice.Gid,
-			}
-			if hostDevice.Major == 0 && hostDevice.Minor == 0 {
-				// Invalid device, most likely a symbolic link, skip it.
-				continue
-			}
-			found := false
-			for i, dev := range settings.OCISpecification.Linux.Devices {
-				if dev.Path == rd.Path {
-					found = true
-					settings.OCISpecification.Linux.Devices[i] = rd
-					break
-				}
-				if dev.Type == rd.Type && dev.Major == rd.Major && dev.Minor == rd.Minor {
-					logrus.WithFields(logrus.Fields{
-						"cid": id,
-					}).Warnf("opengcs::CreateContainer - The same type '%s', major '%d' and minor '%d', should not be used for multiple devices.", dev.Type, dev.Major, dev.Minor)
-				}
-			}
-			if !found {
-				settings.OCISpecification.Linux.Devices = append(settings.OCISpecification.Linux.Devices, rd)
-			}
-		}
-
-		// Set the cgroup access
-		settings.OCISpecification.Linux.Resources.Devices = []oci.LinuxDeviceCgroup{
-			{
-				Allow:  true,
-				Access: "rwm",
-			},
-		}
-	}
-
-	// Container doesnt exit. Create it here
 	// Create the BundlePath
 	if err := os.MkdirAll(settings.OCIBundlePath, 0700); err != nil {
 		return nil, errors.Wrapf(err, "failed to create OCIBundlePath: '%s'", settings.OCIBundlePath)
@@ -241,18 +149,21 @@ func (h *Host) CreateContainer(id string, settings *prot.VMHostedContainerSettin
 	c.processesWg.Add(1)
 	c.initProcess = newProcess(c, settings.OCISpecification.Process, con.(runtime.Process), uint32(c.container.Pid()), true)
 
-	// For the sandbox move all adapters into the network namespace
-	if isSandboxOrStandalone && networkNamespace != "" {
-		if netopts, ok := h.netNamespaces[networkNamespace]; ok {
-			for _, a := range netopts.Adapters {
-				err = c.AddNetworkAdapter(a)
-				if err != nil {
-					return nil, err
-				}
+	// Sandbox or standalone, move the networks to the container namespace
+	if criType == "sandbox" || !isCRI {
+		ns, err := getNetworkNamespace(namespaceID)
+		if isCRI && err != nil {
+			return nil, err
+		}
+		// standalone is not required to have a networking namespace setup
+		if ns != nil {
+			if err := ns.AssignContainerPid(context.TODO(), c.container.Pid()); err != nil {
+				return nil, err
+			}
+			if err := ns.Sync(context.TODO()); err != nil {
+				return nil, err
 			}
 		}
-		// Add a link for all HotAdd/Remove from NS id to this container.
-		h.networkNSToContainer.Store(networkNamespace, id)
 	}
 
 	h.containers[id] = c
@@ -352,49 +263,19 @@ func (h *Host) ModifyHostSettings(settings *prot.ModifySettingRequest) error {
 	case prot.MrtNetwork:
 		add = func(setting interface{}) error {
 			na := setting.(*prot.NetworkAdapterV2)
-			na.ID = strings.ToLower(na.ID)
-			na.NamespaceID = strings.ToLower(na.NamespaceID)
-			if cidraw, ok := h.networkNSToContainer.Load(na.NamespaceID); ok {
-				// The container has already been created. Get it and add this
-				// adapter in real time.
-				c, err := h.GetContainer(cidraw.(string))
-				if err != nil {
-					return err
-				}
-				return c.AddNetworkAdapter(na)
+			ns := getOrAddNetworkNamespace(na.NamespaceID)
+			if err := ns.AddAdapter(context.TODO(), na); err != nil {
+				return err
 			}
-			netopts, ok := h.netNamespaces[na.NamespaceID]
-			if !ok {
-				netopts = &netNSOpts{}
-				h.netNamespaces[na.NamespaceID] = netopts
-			}
-			netopts.Adapters = append(netopts.Adapters, na)
-			return nil
+			// This code doesnt know if the namespace was already added to the
+			// container or not so it must always call `Sync`.
+			return ns.Sync(context.TODO())
 		}
 		remove = func(setting interface{}) error {
 			na := setting.(*prot.NetworkAdapterV2)
-			na.ID = strings.ToLower(na.ID)
-			na.NamespaceID = strings.ToLower(na.NamespaceID)
-			if cidraw, ok := h.networkNSToContainer.Load(na.NamespaceID); ok {
-				// The container was previously created or is still. Remove the
-				// network. If the container is not found we just remove the
-				// namespace reference.
-				if c, err := h.GetContainer(cidraw.(string)); err == nil {
-					return c.RemoveNetworkAdapter(na.ID)
-				}
-			} else {
-				if netopts, ok := h.netNamespaces[na.NamespaceID]; ok {
-					var i int
-					var a *prot.NetworkAdapterV2
-					for i, a = range netopts.Adapters {
-						if na.ID == a.ID {
-							break
-						}
-					}
-					if a != nil {
-						netopts.Adapters = append(netopts.Adapters[:i], netopts.Adapters[i+1:]...)
-					}
-				}
+			ns := getOrAddNetworkNamespace(na.ID)
+			if err := ns.RemoveAdapter(context.TODO(), na.ID); err != nil {
+				return err
 			}
 			return nil
 		}

--- a/internal/runtime/hcsv2/workload_container.go
+++ b/internal/runtime/hcsv2/workload_container.go
@@ -1,0 +1,144 @@
+package hcsv2
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/opencontainers/runc/libcontainer/devices"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+func getWorkloadRootDir(sbid, id string) string {
+	return filepath.Join(getSandboxRootDir(sbid), id)
+}
+
+func setupWorkloadContainerSpec(ctx context.Context, sbid, id string, spec *oci.Spec) (err error) {
+	// TODO: JTERRY75 use ctx for log
+	operation := "setupWorkloadContainerSpec"
+	start := time.Now()
+	defer func() {
+		end := time.Now()
+		fields := logrus.Fields{
+			"cid":       id,
+			"startTime": start,
+			"endTime":   end,
+			"duration":  end.Sub(start),
+		}
+		if err != nil {
+			fields[logrus.ErrorKey] = err
+			logrus.WithFields(fields).Error(operation)
+		} else {
+			logrus.WithFields(fields).Info(operation)
+		}
+	}()
+
+	// Verify no hostname
+	if spec.Hostname != "" {
+		return errors.Errorf("workload container must not change hostname: %s", spec.Hostname)
+	}
+
+	// Add /etc/hostname if the spec did not override it.
+	if !isInMounts("/etc/hostname", spec.Mounts) {
+		mt := oci.Mount{
+			Destination: "/etc/hostname",
+			Type:        "bind",
+			Source:      getSandboxHostnamePath(sbid),
+			Options:     []string{"bind"},
+		}
+		if isRootReadonly(spec) {
+			mt.Options = append(mt.Options, "ro")
+		}
+		spec.Mounts = append(spec.Mounts, mt)
+	}
+
+	// Add /etc/hosts if the spec did not override it.
+	if !isInMounts("/etc/hosts", spec.Mounts) {
+		mt := oci.Mount{
+			Destination: "/etc/hosts",
+			Type:        "bind",
+			Source:      getSandboxHostsPath(sbid),
+			Options:     []string{"bind"},
+		}
+		if isRootReadonly(spec) {
+			mt.Options = append(mt.Options, "ro")
+		}
+		spec.Mounts = append(spec.Mounts, mt)
+	}
+
+	// Add /etc/resolv.conf if the spec did not override it.
+	if !isInMounts("/etc/resolv.conf", spec.Mounts) {
+		mt := oci.Mount{
+			Destination: "/etc/resolv.conf",
+			Type:        "bind",
+			Source:      getSandboxResolvPath(sbid),
+			Options:     []string{"bind"},
+		}
+		if isRootReadonly(spec) {
+			mt.Options = append(mt.Options, "ro")
+		}
+		spec.Mounts = append(spec.Mounts, mt)
+	}
+
+	// TODO: JTERRY75 /dev/shm is not properly setup for LCOW I believe. CRI
+	// also has a concept of a sandbox/shm file when the IPC NamespaceMode !=
+	// NODE.
+
+	// Check if we need to do any capability/device mappings
+	if spec.Annotations["io.microsoft.virtualmachine.lcow.privileged"] == "true" {
+		logrus.WithFields(logrus.Fields{
+			"cid": id,
+		}).Debugf("setupWorkloadContainerSpec - 'io.microsoft.virtualmachine.lcow.privileged' set for privileged container")
+
+		// Add all host devices
+		hostDevices, err := devices.HostDevices()
+		if err != nil {
+			return err
+		}
+		for _, hostDevice := range hostDevices {
+			rd := oci.LinuxDevice{
+				Path:  hostDevice.Path,
+				Type:  string(hostDevice.Type),
+				Major: hostDevice.Major,
+				Minor: hostDevice.Minor,
+				UID:   &hostDevice.Uid,
+				GID:   &hostDevice.Gid,
+			}
+			if hostDevice.Major == 0 && hostDevice.Minor == 0 {
+				// Invalid device, most likely a symbolic link, skip it.
+				continue
+			}
+			found := false
+			for i, dev := range spec.Linux.Devices {
+				if dev.Path == rd.Path {
+					found = true
+					spec.Linux.Devices[i] = rd
+					break
+				}
+				if dev.Type == rd.Type && dev.Major == rd.Major && dev.Minor == rd.Minor {
+					logrus.WithFields(logrus.Fields{
+						"cid": id,
+					}).Warnf("setupWorkloadContainerSpec - The same type '%s', major '%d' and minor '%d', should not be used for multiple devices.", dev.Type, dev.Major, dev.Minor)
+				}
+			}
+			if !found {
+				spec.Linux.Devices = append(spec.Linux.Devices, rd)
+			}
+		}
+
+		// Set the cgroup access
+		spec.Linux.Resources.Devices = []oci.LinuxDeviceCgroup{
+			{
+				Allow:  true,
+				Access: "rwm",
+			},
+		}
+	}
+
+	// Clear the windows section as we dont want to forward to runc
+	spec.Windows = nil
+
+	return nil
+}


### PR DESCRIPTION
1. Modifies the existing networking model to properly allocate namespaces only
for standalone or sandbox containers.
2. Modifies the existing /etc/resolv.conf handling to properly create for
standalone or sandbox containers but bind mount for workload containers.
3. Adds support for mapping the sandbox containers /etc/hostname to the
workload container.
4. Adds support for mapping the sandbox containers /etc/hosts file to the
workload container.
5. Adds support to standalone containers for /etc/hostname and /etc/hosts
files.