### PR TITLE
Stop logging expected error values

### DIFF
--- a/internal/runtime/hcsv2/process.go
+++ b/internal/runtime/hcsv2/process.go
@@ -108,7 +108,11 @@ func newProcess(c *Container, spec *oci.Process, process runtime.Process, pid ui
 func (p *Process) Kill(ctx context.Context, signal syscall.Signal) (err error) {
 	_, span := trace.StartSpan(ctx, "opengcs::Process::Kill")
 	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
+	defer func() {
+		if !gcserr.IsNotFound(err) {
+			oc.SetSpanStatus(span, err)
+		}
+	}()
 	span.AddAttributes(
 		trace.StringAttribute("cid", p.cid),
 		trace.Int64Attribute("pid", int64(p.pid)),

--- a/service/gcs/bridge/bridge_v2.go
+++ b/service/gcs/bridge/bridge_v2.go
@@ -283,7 +283,11 @@ func (b *Bridge) signalContainerV2(ctx context.Context, span *trace.Span, r *Req
 func (b *Bridge) signalProcessV2(r *Request) (_ RequestResponse, err error) {
 	ctx, span := trace.StartSpan(r.Context, "opengcs::bridge::signalProcessV2")
 	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
+	defer func() {
+		if !gcserr.IsNotFound(err) {
+			oc.SetSpanStatus(span, err)
+		}
+	}()
 	span.AddAttributes(
 		trace.StringAttribute("activityID", r.ActivityID),
 		trace.StringAttribute("cid", r.ContainerID))

--- a/service/gcs/gcserr/errors.go
+++ b/service/gcs/gcserr/errors.go
@@ -39,6 +39,13 @@ const (
 	HrVmcomputeUnknownMessage = Hresult(-1070137077) // 0xC037010B
 )
 
+// IsNotFound returns `true` if `err` is either `HrErrNotFound` or
+// `HrVmcomputeSystemNotFound`.
+func IsNotFound(err error) bool {
+	hr, _ := GetHresult(err)
+	return hr == HrErrNotFound || hr == HrVmcomputeSystemNotFound
+}
+
 // StackTracer is an interface originating (but not exported) from the
 // github.com/pkg/errors package. It defines something which can return a stack
 // trace.


### PR DESCRIPTION
Some GCS* functions return errors to signify a success with additional
information. In these casses we need to skip logging the error because the use
case is expected and this isn't an error for the client who handles it.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>