### PR TITLE
init: Add option to initialize entropy from vsock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     rm -rf /target/etc/apk /target/lib/apk /target/var/cache && \
     \
     # Install the build packages
-    apk add --no-cache build-base curl git musl-dev libarchive-tools e2fsprogs file && \
+    apk add --no-cache build-base curl git musl-dev linux-headers libarchive-tools e2fsprogs file && \
     \
     # Grab udhcpc_config.script
     curl -fSL "https://raw.githubusercontent.com/mirror/busybox/38d966943f5288bb1f2e7219f50a92753c730b14/examples/udhcp/simple.script" -o /target/sbin/udhcpc_config.script && \

--- a/Makefile
+++ b/Makefile
@@ -78,13 +78,13 @@ out/initrd.img: $(BASE) out/delta.tar.gz $(SRCROOT)/hack/catcpio.sh
 
 VPATH=$(SRCROOT)
 
-bin/vsockexec: vsockexec/vsockexec.o
+bin/vsockexec: vsockexec/vsockexec.o vsockexec/vsock.o
 	@mkdir -p bin
-	$(CC) $(LDFLAGS) -o $@ $<
+	$(CC) $(LDFLAGS) -o $@ $^
 
-bin/init: init/init.o
+bin/init: init/init.o vsockexec/vsock.o
 	@mkdir -p bin
-	$(CC) $(LDFLAGS) -o $@ $<
+	$(CC) $(LDFLAGS) -o $@ $^
 
 %.o: %.c
 	@mkdir -p $(dir $@)

--- a/vsockexec/vsock.c
+++ b/vsockexec/vsock.c
@@ -1,0 +1,30 @@
+#include "vsock.h"
+#include <sys/socket.h>
+
+struct sockaddr_vm {
+	unsigned short svm_family;
+	unsigned short svm_reserved1;
+	unsigned int svm_port;
+	unsigned int svm_cid;
+	unsigned char svm_zero[sizeof(struct sockaddr) -
+			       sizeof(sa_family_t) -
+			       sizeof(unsigned short) -
+			       sizeof(unsigned int) - sizeof(unsigned int)];
+};
+
+int openvsock(unsigned int cid, unsigned int port) {
+    int s = socket(AF_VSOCK, SOCK_STREAM, 0);
+    if (s < 0) {
+        return -1;
+    }
+
+    struct sockaddr_vm addr = {0};
+    addr.svm_family = AF_VSOCK;
+    addr.svm_port = port;
+    addr.svm_cid = cid;
+    if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+        return -1;
+    }
+
+    return s;
+}

--- a/vsockexec/vsock.h
+++ b/vsockexec/vsock.h
@@ -1,0 +1,8 @@
+#ifndef VSOCK_H
+#define VSOCK_H
+
+#define VMADDR_CID_HOST 2
+
+int openvsock(unsigned int cid, unsigned int port);
+
+#endif

--- a/vsockexec/vsockexec.c
+++ b/vsockexec/vsockexec.c
@@ -8,6 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include "vsock.h"
 
 #ifdef USE_TCP
 static const int tcpmode = 1;
@@ -15,44 +16,10 @@ static const int tcpmode = 1;
 static const int tcpmode;
 #endif
 
-struct sockaddr_vm {
-	unsigned short svm_family;
-	unsigned short svm_reserved1;
-	unsigned int svm_port;
-	unsigned int svm_cid;
-	unsigned char svm_zero[sizeof(struct sockaddr) -
-			       sizeof(sa_family_t) -
-			       sizeof(unsigned short) -
-			       sizeof(unsigned int) - sizeof(unsigned int)];
-};
-
-#define VMADDR_CID_HOST 2
-
-static int openvsock(unsigned int cid, unsigned int port)
-{
-    int s = socket(AF_VSOCK, SOCK_STREAM, 0);
-    if (s < 0) {
-        perror("socket: AF_VSOCK");
-        return -1;
-    }
-
-    struct sockaddr_vm addr = {0};
-    addr.svm_family = AF_VSOCK;
-    addr.svm_port = port;
-    addr.svm_cid = cid;
-    if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        fprintf(stderr, "connect: port %u: %s", port, strerror(errno));
-        return -1;
-    }
-
-    return s;
-}
-
 static int opentcp(unsigned short port)
 {
     int s = socket(AF_INET, SOCK_STREAM, 0);
     if (s < 0) {
-        perror("socket: AF_INET");
         return -1;
     }
 
@@ -61,7 +28,6 @@ static int opentcp(unsigned short port)
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
     if (connect(s, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-        fprintf(stderr, "connect: port %u: %s\n", port, strerror(errno));
         return -1;
     }
 
@@ -121,6 +87,7 @@ int main(int argc, char **argv)
             if (j == i) {
                 int s = tcpmode ? opentcp(ports[i]) : openvsock(VMADDR_CID_HOST, ports[i]);
                 if (s < 0) {
+                    fprintf(stderr, "connect: port %u: %s", ports[i], strerror(errno));
                     return 1;
                 }
                 sockets[i] = s;


### PR DESCRIPTION
This change adds a command line option, -e, that specifies a vsock port
to read initial RNG entropy. init reads all data written to the
connection by the host, adds this data to the kernel RNG, and increments
the available entropy count. The host is trusted to write
cryptographically random data to this port.

Without this, the available entropy at LCOW boot is very low, and data
read from /dev/urandom is likely to be highly predicable.