### PR TITLE
Do not wait for outstanding execs on container exit

### DIFF
--- a/internal/runtime/hcsv2/process.go
+++ b/internal/runtime/hcsv2/process.go
@@ -77,10 +77,6 @@ func newProcess(c *Container, spec *oci.Process, process runtime.Process, pid ui
 
 		// Free any process waiters
 		p.exitWg.Done()
-		// Decrement any container process count waiters
-		c.processesMutex.Lock()
-		c.processesWg.Done()
-		c.processesMutex.Unlock()
 
 		// Schedule the removal of this process object from the map once at
 		// least one waiter has read the result

--- a/internal/runtime/hcsv2/uvm.go
+++ b/internal/runtime/hcsv2/uvm.go
@@ -143,8 +143,6 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		exitType:  prot.NtUnexpectedExit,
 		processes: make(map[uint32]*Process),
 	}
-	// Add the WG count for the init process
-	c.processesWg.Add(1)
 	c.initProcess = newProcess(c, settings.OCISpecification.Process, con.(runtime.Process), uint32(c.container.Pid()), true)
 
 	// Sandbox or standalone, move the networks to the container namespace


### PR DESCRIPTION
1. The expectation of containerd is that when a process exits the exit
notification is sent. But it is also possible in the api to signal a container
exit without using all=true thus outstanding execs may be running when the exit
should fire. This enables the caller to receive the notification and then
handle the shutdown properly.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>