### PR TITLE
Support mount propagation for sandbox mounts

### DIFF
--- a/internal/runtime/hcsv2/sandbox_container.go
+++ b/internal/runtime/hcsv2/sandbox_container.go
@@ -18,6 +18,10 @@ func getSandboxRootDir(id string) string {
 	return filepath.Join("/tmp/gcs/cri", id)
 }
 
+func getSandboxMountsDir(id string) string {
+	return filepath.Join(getSandboxRootDir(id), "sandboxMounts")
+}
+
 func getSandboxHostnamePath(id string) string {
 	return filepath.Join(getSandboxRootDir(id), "hostname")
 }

--- a/internal/storage/mount.go
+++ b/internal/storage/mount.go
@@ -4,7 +4,9 @@ package storage
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"syscall"
 
 	"github.com/Microsoft/opengcs/internal/oc"
 	"github.com/pkg/errors"
@@ -16,8 +18,24 @@ import (
 var (
 	osStat      = os.Stat
 	unixUnmount = unix.Unmount
+	unixMount   = unix.Mount
 	osRemoveAll = os.RemoveAll
 )
+
+// MountRShared creates a bind mountpoint and marks it as rshared
+// Expected that the filepath exists before calling this function
+func MountRShared(path string) error {
+	if path == "" {
+		return errors.New("Path must not be empty to mount as rshared")
+	}
+	if err := unixMount(path, path, "", syscall.MS_BIND, ""); err != nil {
+		return fmt.Errorf("Failed to create bind mount for %v: %v", path, err)
+	}
+	if err := unixMount(path, path, "", syscall.MS_SHARED|syscall.MS_REC, ""); err != nil {
+		return fmt.Errorf("Failed to make %v rshared: %v", path, err)
+	}
+	return nil
+}
 
 // UnmountPath unmounts the target path if it exists and is a mount path. If
 // removeTarget this will remove the previously mounted folder.


### PR DESCRIPTION
* This change creates a new dedicated directory path in the uvm for all
sandbox mounts at /tmp/gcs/cri/<sandboxid>/sandboxMounts.
* The above path will be marked as rshared
* OpenGCS now expects sandbox mounts to be given with a source prefix
of 'sandbox://'
* OpenGCS will also create any files or directories in the resulting
source sandbox mount path.

Needs: https://github.com/microsoft/hcsshim/pull/710

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>