### PR TITLE
Fix nil dereference race in Pipe/TtyRelay Wait

### DIFF
--- a/service/gcs/stdio/stdio.go
+++ b/service/gcs/stdio/stdio.go
@@ -243,13 +243,15 @@ func (pr *PipeRelay) Wait() {
 	// because the host expects stdin to be closed before it will report process
 	// exit back to the client, and the client expects the process notification before
 	// it will close its side of stdin (which io.Copy is waiting on in the copying goroutine).
-	if pr.s.In != nil {
+	if pr.s != nil && pr.s.In != nil {
 		pr.s.In.CloseRead()
 	}
 
 	pr.wg.Wait()
 	pr.closePipes()
-	pr.s.Close()
+	if pr.s != nil {
+		pr.s.Close()
+	}
 }
 
 // CloseUnusedPipes gives the caller the ability to close any pipes that do not
@@ -355,7 +357,7 @@ func (r *TtyRelay) Wait() {
 	// because the host expects stdin to be closed before it will report process
 	// exit back to the client, and the client expects the process notification before
 	// it will close its side of stdin (which io.Copy is waiting on in the copying goroutine).
-	if r.s.In != nil {
+	if r.s != nil && r.s.In != nil {
 		r.s.In.CloseRead()
 	}
 
@@ -367,5 +369,7 @@ func (r *TtyRelay) Wait() {
 
 	r.pty.Close()
 	r.closed = true
-	r.s.Close()
+	if r.s != nil {
+		r.s.Close()
+	}
 }


### PR DESCRIPTION
The process for creating a V2 container is separated into a few different
steps. First a CreateContainer is called which creates the actual runc
container process with a standard pipe relay but no upstream IO. Next the HCS
sends an ExecProcess call passing in the upstream IO to relay to. If that call
fails, when the HCS calls Kill on the container the relay wait code would panic
because the upstream IO had never been assigned.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>