### PR TITLE
Fix issue causing SCSI hot add to find no matching device

### DIFF
--- a/internal/storage/scsi/scsi.go
+++ b/internal/storage/scsi/scsi.go
@@ -100,18 +100,18 @@ func ControllerLunToName(ctx context.Context, controller, lun uint8) (_ string, 
 	var deviceNames []os.FileInfo
 	for {
 		deviceNames, err = ioutil.ReadDir(blockPath)
-		if err != nil {
-			if os.IsNotExist(err) {
-				select {
-				case <-ctx.Done():
-					return "", ctx.Err()
-				default:
-					time.Sleep(time.Millisecond * 10)
-					continue
-				}
-			}
+		if err != nil && !os.IsNotExist(err) {
 			return "", err
 		}
+		if len(deviceNames) == 0 {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			default:
+				time.Sleep(time.Millisecond * 10)
+				continue
+			}
+		} 
 		break
 	}
 


### PR DESCRIPTION
It appears there is a timing issue in the current code that checks for the
SCSI device to be added. We were waiting for the /block folder to show up but
then immediately read the device entries. There is some amount of time that it
can take for that to show up as well. So this change now waits for both the
/block and /block/sd* entry under the same context timeout.

Signed-off-by: Justin Terry (VM) <juterry@microsoft.com>