### PR TITLE
add new delete container state bridge call

### DIFF
--- a/internal/runtime/hcsv2/uvm.go
+++ b/internal/runtime/hcsv2/uvm.go
@@ -56,6 +56,13 @@ func NewHost(rtime runtime.Runtime, vsock transport.Transport) *Host {
 	}
 }
 
+func (h *Host) RemoveContainer(id string) {
+	h.containersMutex.Lock()
+	defer h.containersMutex.Unlock()
+
+	delete(h.containers, id)
+}
+
 func (h *Host) getContainerLocked(id string) (*Container, error) {
 	if c, ok := h.containers[id]; !ok {
 		return nil, gcserr.NewHresultError(gcserr.HrVmcomputeSystemNotFound)
@@ -157,6 +164,7 @@ func (h *Host) CreateContainer(ctx context.Context, id string, settings *prot.VM
 		id:        id,
 		vsock:     h.vsock,
 		spec:      settings.OCISpecification,
+		isSandbox: criType == "sandbox",
 		container: con,
 		exitType:  prot.NtUnexpectedExit,
 		processes: make(map[uint32]*containerProcess),

--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -233,6 +233,7 @@ func (b *Bridge) AssignHandlers(mux *Mux, gcs core.Core, host *hcsv2.Host) {
 		mux.HandleFunc(prot.ComputeSystemResizeConsoleV1, prot.PvV4, b.resizeConsoleV2)
 		mux.HandleFunc(prot.ComputeSystemModifySettingsV1, prot.PvV4, b.modifySettingsV2)
 		mux.HandleFunc(prot.ComputeSystemDumpStacksV1, prot.PvV4, b.dumpStacksV2)
+		mux.HandleFunc(prot.ComputeSystemDeleteContainerStateV1, prot.PvV4, b.deleteContainerStateV2)
 	}
 }
 

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -102,6 +102,8 @@ const (
 	ComputeSystemNegotiateProtocolV1 = 0x10100b01
 	// ComputeSystemDumpStackV1 is the dump stack request
 	ComputeSystemDumpStacksV1 = 0x10100c01
+	// ComputeSystemDeleteContainerStateV1 is the delete container request.
+	ComputeSystemDeleteContainerStateV1 = 0x10100d01
 
 	// ComputeSystemResponseCreateV1 is the create container response.
 	ComputeSystemResponseCreateV1 = 0x20100101
@@ -166,6 +168,8 @@ func (mi MessageIdentifier) String() string {
 		return "ComputeSystemNegotiateProtocolV1"
 	case ComputeSystemDumpStacksV1:
 		return "ComputeSystemDumpStacksV1"
+	case ComputeSystemDeleteContainerStateV1:
+		return "ComputeSystemDeleteContainerStateV1"
 	case ComputeSystemResponseCreateV1:
 		return "ComputeSystemResponseCreateV1"
 	case ComputeSystemResponseStartV1:
@@ -264,9 +268,10 @@ type GcsCapabilities struct {
 // GcsGuestCapabilities represents the customized guest capabilities supported
 // by this GCS.
 type GcsGuestCapabilities struct {
-	NamespaceAddRequestSupported bool `json:",omitempty"`
-	SignalProcessSupported       bool `json:",omitempty"`
-	DumpStacksSupported          bool `json:",omitempty"`
+	NamespaceAddRequestSupported  bool `json:",omitempty"`
+	SignalProcessSupported        bool `json:",omitempty"`
+	DumpStacksSupported           bool `json:",omitempty"`
+	DeleteContainerStateSupported bool `json:",omitempty"`
 }
 
 // ocspancontext is the internal JSON representation of the OpenCensus


### PR DESCRIPTION
* add delete container state capability for opengcs
* delete container state bridge call calls runc delete for container
* delete container state bridge call unmounts user mounts on sandbox
mounts
* add new function to unmount all paths under a given path
* add tests for new unmount function

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>