### PR TITLE
Guest GPU assigned device support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ GCS_TOOLS=\
 	vhd2tar \
 	exportSandbox \
 	netnscfg \
-	remotefs
+	remotefs \
+	nvidiaPrestartHook
 
 .PHONY: all always rootfs test
 

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/opencontainers/runc v1.0.0-rc2.0.20190926000215-3e425f80a8c9 h1:x4NaJ
 github.com/opencontainers/runc v1.0.0-rc2.0.20190926000215-3e425f80a8c9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700 h1:eNUVfm/RFLIi1G7flU5/ZRTHvd4kcVuzfRnL6OFlzCI=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/opencontainers/runtime-spec v1.0.1 h1:wY4pOY8fBdSIvs9+IDHC55thBuEulhzfSgKeC1yFvzQ=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Microsoft/opengcs/internal/log"
 	"github.com/Microsoft/opengcs/internal/oc"
+	"github.com/Microsoft/opengcs/internal/storage/vmbus"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 )
@@ -111,7 +112,9 @@ func InstanceIDToName(ctx context.Context, id string) (_ string, err error) {
 	id = strings.ToLower(id)
 	span.AddAttributes(trace.StringAttribute("adapterInstanceID", id))
 
-	devicePath := filepath.Join("/sys", "bus", "vmbus", "devices", id, "net")
+	vmBusSubPath := filepath.Join(id, "net")
+	devicePath, err := vmbus.WaitForDevicePath(ctx, vmBusSubPath)
+
 	var deviceDirs []os.FileInfo
 	for {
 		deviceDirs, err = ioutil.ReadDir(devicePath)

--- a/internal/runtime/hcsv2/nvidia_utils.go
+++ b/internal/runtime/hcsv2/nvidia_utils.go
@@ -1,0 +1,91 @@
+// +build linux
+
+package hcsv2
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/Microsoft/opengcs/internal/storage/pci"
+	oci "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/pkg/errors"
+)
+
+// path that the shim mounts the nvidia gpu vhd to in the uvm
+// this MUST match the path mapped to in the shim
+const lcowNvidiaMountPath = "/run/nvidia"
+
+// annotation to find the gpu capabilities on the container spec
+// must match the hcsshim annotation string for gpu capabilities
+const annotationContainerGPUCapabilities = "io.microsoft.container.gpu.capabilities"
+const nvidiaDebugFilePath = "/nvidia-container.log"
+
+// TODO katiewasnothere: prestart hooks will be depracated, this needs to be moved to a createRuntime hook
+// described here: https://github.com/opencontainers/runtime-spec/blob/39c287c415bf86fb5b7506528d471db5405f8ca8/config.md#posix-platform-hooks
+// addNvidiaDevicePreHook builds the arguments for nvidia-container-cli and creates the prestart hook
+func addNvidiaDevicePreHook(ctx context.Context, spec *oci.Spec) error {
+	nvidiaToolBinary := "nvidiaPrestartHook"
+	nvidiaToolPath, err := exec.LookPath(nvidiaToolBinary)
+	if err != nil {
+		return errors.Wrapf(err, "failed to find %s for container GPU support", nvidiaToolBinary)
+	}
+
+	debugOption := fmt.Sprintf("--debug=%s", nvidiaDebugFilePath)
+
+	// TODO katiewasnothere: right now both host and container ldconfig do not work as expected for nvidia-container-cli
+	// ldconfig needs to be run in the container to setup the correct symlinks to the library files nvidia-container-cli
+	// maps into the container
+	args := []string{nvidiaToolPath, debugOption, "--load-kmods", "--no-pivot", "configure", "--ldconfig=@/sbin/ldconfig"}
+	if capabilities, ok := spec.Annotations[annotationContainerGPUCapabilities]; ok {
+		caps := strings.Split(capabilities, ",")
+		for _, c := range caps {
+			args = append(args, fmt.Sprintf("--%s", c))
+		}
+	}
+
+	for _, d := range spec.Windows.Devices {
+		switch d.IDType {
+		case "gpu":
+			busLocation, err := pci.FindDeviceBusLocationFromVMBusGUID(ctx, d.ID)
+			if err != nil {
+				return errors.Wrapf(err, "failed to find nvidia gpu bus location")
+			}
+			args = append(args, fmt.Sprintf("--device=%s", busLocation))
+		}
+	}
+
+	args = append(args, "--no-cgroups", "--pid=%v", spec.Root.Path)
+
+	if spec.Hooks == nil {
+		spec.Hooks = &oci.Hooks{}
+	}
+
+	nvidiaHook := oci.Hook{
+		Path: nvidiaToolPath,
+		Args: args,
+		Env:  updateEnvWithNvidiaVariables(),
+	}
+
+	spec.Hooks.Prestart = append(spec.Hooks.Prestart, nvidiaHook)
+	return nil
+}
+
+// updateEnvWithNvidiaVariables creates an env with the nvidia gpu vhd in PATH and insecure mode set
+func updateEnvWithNvidiaVariables() []string {
+	pathPrefix := "PATH="
+	nvidiaBin := fmt.Sprintf("%s/bin", lcowNvidiaMountPath)
+	env := os.Environ()
+	for i, v := range env {
+		if strings.HasPrefix(v, pathPrefix) {
+			newPath := fmt.Sprintf("%s:%s", v, nvidiaBin)
+			env[i] = newPath
+		}
+	}
+	// NVC_INSECURE_MODE allows us to run nvidia-container-cli without seccomp
+	// we don't currently use seccomp in the uvm, so avoid using it here for now as well
+	env = append(env, "NVC_INSECURE_MODE=1")
+	return env
+}

--- a/internal/storage/pci/pci.go
+++ b/internal/storage/pci/pci.go
@@ -1,0 +1,64 @@
+// +build linux
+
+package pci
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/Microsoft/opengcs/internal/storage"
+	"github.com/Microsoft/opengcs/internal/storage/vmbus"
+)
+
+var storageWaitForFileMatchingPattern = storage.WaitForFileMatchingPattern
+var vmbusWaitForDevicePath = vmbus.WaitForDevicePath
+
+// WaitForPCIDeviceFromVMBusGUID waits for bus location path of the device to be present
+func WaitForPCIDeviceFromVMBusGUID(ctx context.Context, vmBusGUID string) error {
+	_, err := FindDeviceBusLocationFromVMBusGUID(ctx, vmBusGUID)
+	return err
+}
+
+// FindDeviceBusLocationFromVMBusGUID finds device bus location by
+// reading /sys/bus/vmbus/devices/<vmBusGUID>/... for pci specific directories
+func FindDeviceBusLocationFromVMBusGUID(ctx context.Context, vmBusGUID string) (string, error) {
+	pciDir, err := findVMBusPCIDir(ctx, vmBusGUID)
+	if err != nil {
+		return "", err
+	}
+
+	pciDeviceLocation, err := findVMBusPCIDevice(ctx, pciDir)
+	if err != nil {
+		return "", err
+	}
+	return pciDeviceLocation, nil
+}
+
+// findVMBusPCIDir waits for the pci bus directory matching pattern
+// /sys/bus/vmbus/devices/<vmBusGUID>/pci* to exist and returns
+// the full resulting path or an error
+func findVMBusPCIDir(ctx context.Context, vmBusGUID string) (string, error) {
+	vmBusPCIPathPattern := filepath.Join(vmBusGUID, "pci*")
+	return vmbusWaitForDevicePath(ctx, vmBusPCIPathPattern)
+}
+
+// findVMBusPCIDevice waits for the pci bus location directory under the path
+// returned from findVMBusPCIDir to exist and returns the pci bus location or an error
+func findVMBusPCIDevice(ctx context.Context, pciDirFullPath string) (string, error) {
+	// trim /sys/bus/vmbus/devices/<vmBusGUID>/pciXXXX:XX to XXXX:XX
+	_, pciDirName := filepath.Split(pciDirFullPath)
+	busPrefix := strings.TrimPrefix(pciDirName, "pci")
+
+	// under /sys/bus/vmbus/devices/<vmBusGUID>/pciXXXX:XX/ look for directory matching XXXX:XX* pattern
+	busPathPattern := filepath.Join(pciDirFullPath, fmt.Sprintf("%s*", busPrefix))
+	busFileFullPath, err := storageWaitForFileMatchingPattern(ctx, busPathPattern)
+	if err != nil {
+		return "", err
+	}
+
+	// return the resulting XXXX:XX:YY.Y pci bus location
+	_, busFile := filepath.Split(busFileFullPath)
+	return busFile, nil
+}

--- a/internal/storage/pci/pci_test.go
+++ b/internal/storage/pci/pci_test.go
@@ -1,0 +1,43 @@
+// +build linux
+
+package pci
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func Test_WaitForPCIDeviceFromVMBusGUID_Success(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+
+	vmBusGUID := "1111-2222-3333-4444"
+	pciDir := "pci1234:00"
+	busLocation := "1234:00:00.0"
+
+	vmbusWaitForDevicePath = func(ctx context.Context, vmbusGUIDPattern string) (string, error) {
+		vmBusPath := filepath.Join("/sys/bus/vmbus/devices", vmbusGUIDPattern)
+		vmBusDirPath, targetPattern := filepath.Split(vmBusPath)
+		if targetPattern == "pci*" {
+			return filepath.Join(vmBusDirPath, pciDir), nil
+		}
+		return "", nil
+	}
+
+	storageWaitForFileMatchingPattern = func(ctx context.Context, pattern string) (string, error) {
+		vmBusPciDirPath, targetPattern := filepath.Split(pattern)
+		if targetPattern == "1234:00*" {
+			return filepath.Join(vmBusPciDirPath, busLocation), nil
+		}
+		return "", nil
+	}
+
+	resultBusLocation, err := FindDeviceBusLocationFromVMBusGUID(ctx, vmBusGUID)
+	if err != nil {
+		t.Fatalf("expected to succeed, instead got: %v", err)
+	}
+	if resultBusLocation != busLocation {
+		t.Fatalf("result %s does not match expected result %s", resultBusLocation, busLocation)
+	}
+}

--- a/internal/storage/utilities.go
+++ b/internal/storage/utilities.go
@@ -1,0 +1,38 @@
+// +build linux
+
+package storage
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// export this variable so it can be mocked to aid in testing for consuming packages
+var filepathglob = filepath.Glob
+
+// WaitForFileMatchingPattern waits for a single file that matches the given path pattern and returns the full path
+// to the resulting file
+func WaitForFileMatchingPattern(ctx context.Context, pattern string) (string, error) {
+	for {
+		files, err := filepathglob(pattern)
+		if err != nil {
+			return "", err
+		}
+		if len(files) == 0 {
+			select {
+			case <-ctx.Done():
+				return "", errors.Wrapf(ctx.Err(), "timed out waiting for file matching pattern %s to exist", pattern)
+			default:
+				time.Sleep(time.Millisecond * 10)
+				continue
+			}
+		} else if len(files) > 1 {
+			return "", fmt.Errorf("more than one file could exist for pattern \"%s\"", pattern)
+		}
+		return files[0], nil
+	}
+}

--- a/internal/storage/utilities_test.go
+++ b/internal/storage/utilities_test.go
@@ -1,0 +1,87 @@
+// +build linux
+
+package storage
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func Test_WaitForFileMatchingPattern_Success(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+
+	testDir, err := ioutil.TempDir("", "vmbus_test")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp dir %v", err)
+	}
+	defer os.RemoveAll(testDir)
+
+	actualPath := filepath.Join(testDir, "path1")
+	err = os.Mkdir(actualPath, 0777)
+	if err != nil {
+		t.Fatalf("unexpected error creating test path: %v", err)
+	}
+
+	pathPattern := filepath.Join(testDir, "path*")
+	pathsToTest := []string{actualPath, pathPattern}
+	for _, p := range pathsToTest {
+		result, err := WaitForFileMatchingPattern(ctx, p)
+		if err != nil {
+			t.Fatalf("expected to find path %v but got error: %v", p, err)
+		}
+		if result != actualPath {
+			t.Fatalf("expected to return path %s, instead go %s", actualPath, result)
+		}
+	}
+}
+
+func Test_WaitForFileMatchingPattern_Multiple_Matches(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+
+	testDir, err := ioutil.TempDir("", "vmbus_test")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp dir %v", err)
+	}
+	defer os.RemoveAll(testDir)
+
+	actualPaths := []string{"path1", "path2"}
+	for _, p := range actualPaths {
+		fullPath := filepath.Join(testDir, p)
+		err := os.Mkdir(fullPath, 0777)
+		if err != nil {
+			t.Fatalf("unexpected error creating test path: %v", err)
+		}
+	}
+
+	pathPattern := filepath.Join(testDir, "path*")
+	_, err = WaitForFileMatchingPattern(ctx, pathPattern)
+	if err == nil {
+		t.Fatalf("expected to fail due to multiple matching files")
+	}
+}
+
+func Test_WaitForFileMatchingPattern_No_Matches(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+
+	testDir, err := ioutil.TempDir("", "vmbus_test")
+	if err != nil {
+		t.Fatalf("unexpected error creating temp dir %v", err)
+	}
+	defer os.RemoveAll(testDir)
+
+	actualPath := filepath.Join(testDir, "path1")
+	err = os.Mkdir(actualPath, 0777)
+	if err != nil {
+		t.Fatalf("unexpected error creating test path: %v", err)
+	}
+
+	badTestPath := filepath.Join(testDir, "path2")
+	_, err = WaitForFileMatchingPattern(ctx, badTestPath)
+	if err == nil {
+		t.Fatalf("expected to fail due to no matching files")
+	}
+}

--- a/internal/storage/vmbus/vmbus.go
+++ b/internal/storage/vmbus/vmbus.go
@@ -1,0 +1,18 @@
+// +build linux
+
+package vmbus
+
+import (
+	"context"
+	"path/filepath"
+
+	"github.com/Microsoft/opengcs/internal/storage"
+)
+
+var storageWaitForFileMatchingPattern = storage.WaitForFileMatchingPattern
+
+// WaitForDevicePath waits for the vmbus device to exist at /sys/bus/vmbus/devices/<vmbusGUIDPattern>...
+func WaitForDevicePath(ctx context.Context, vmbusGUIDPattern string) (string, error) {
+	vmBusPath := filepath.Join("/sys/bus/vmbus/devices", vmbusGUIDPattern)
+	return storageWaitForFileMatchingPattern(ctx, vmBusPath)
+}

--- a/internal/storage/vmbus/vmbus_test.go
+++ b/internal/storage/vmbus/vmbus_test.go
@@ -1,0 +1,35 @@
+// +build linux
+
+package vmbus
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func Test_WaitForVMBusDevicePath_Success(t *testing.T) {
+	ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)
+
+	vmBusGUID := "1111-2222-3333-4444"
+	pciDir := "pci1234:00"
+
+	storageWaitForFileMatchingPattern = func(ctx context.Context, pattern string) (string, error) {
+		vmBusDirPath, targetPattern := filepath.Split(pattern)
+		if targetPattern == "pci*" {
+			return filepath.Join(vmBusDirPath, pciDir), nil
+		}
+		return "", nil
+	}
+
+	vmBusGUIDPattern := filepath.Join(vmBusGUID, "pci*")
+	expectedResult := filepath.Join("/sys/bus/vmbus/devices", vmBusGUID, pciDir)
+	result, err := WaitForDevicePath(ctx, vmBusGUIDPattern)
+	if err != nil {
+		t.Fatalf("expected to succeed, instead got: %v", err)
+	}
+	if result != expectedResult {
+		t.Fatalf("result %s does not match expected result %s", result, expectedResult)
+	}
+}

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -514,6 +514,8 @@ const (
 	MrtVPMemDevice = ModifyResourceType("VPMemDevice")
 	// MrtNetwork is the modify resource type for the `NetworkAdapterV2` device.
 	MrtNetwork = ModifyResourceType("Network")
+	// MrtVPCIDevice is the modify resource type for vpci devices
+	MrtVPCIDevice = ModifyResourceType("VPCIDevice")
 )
 
 // ModifyRequestType is the type of operation to perform on a given modify
@@ -659,6 +661,12 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 				return &request, errors.Wrap(err, "failed to unmarshal settings as NetworkAdapterV2")
 			}
 			msr.Settings = na
+		case MrtVPCIDevice:
+			vd := &MappedVPCIDeviceV2{}
+			if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, vd); err != nil {
+				return &request, errors.Wrap(err, "failed to unmarshal settings as MappedVPCIDeviceV2")
+			}
+			msr.Settings = vd
 		default:
 			return &request, errors.Errorf("invalid ResourceType '%s'", msr.ResourceType)
 		}
@@ -832,6 +840,10 @@ type MappedDirectoryV2 struct {
 type MappedVPMemDeviceV2 struct {
 	DeviceNumber uint32 `json:",omitempty"`
 	MountPath    string `json:",omitempty"`
+}
+
+type MappedVPCIDeviceV2 struct {
+	VMBusGUID string `json:",omitempty"`
 }
 
 // VMHostedContainerSettings is the set of settings used to specify the initial

--- a/service/gcsutils/gcstools/main.go
+++ b/service/gcsutils/gcstools/main.go
@@ -7,10 +7,11 @@ import (
 )
 
 var commands = map[string]func(){
-	"vhd2tar":       vhd2tarMain,
-	"exportSandbox": exportSandboxMain,
-	"netnscfg":      netnsConfigMain,
-	"remotefs":      remotefsMain,
+	"vhd2tar":            vhd2tarMain,
+	"exportSandbox":      exportSandboxMain,
+	"netnscfg":           netnsConfigMain,
+	"remotefs":           remotefsMain,
+	"nvidiaPrestartHook": nvidiaPrestartHookMain,
 }
 
 func main() {

--- a/service/gcsutils/gcstools/nvidiaPrestartHook.go
+++ b/service/gcsutils/gcstools/nvidiaPrestartHook.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	nvidiaToolBinary    = "nvidia-container-cli"
+	pidPrefix           = "--pid"
+	lcowNvidiaMountPath = "/run/nvidia"
+	nvidiaDebugFilePath = "/nvidia-container.log"
+)
+
+// from containerd oci-hook.go
+func loadHookState(r io.Reader) (*specs.State, error) {
+	var s *specs.State
+	if err := json.NewDecoder(r).Decode(&s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func runHook() error {
+	state, err := loadHookState(os.Stdin)
+	if err != nil {
+		return err
+	}
+
+	// find the pid argument and replace with correct pid
+	args := os.Args[1:]
+	for i, a := range args {
+		if strings.HasPrefix(a, pidPrefix) {
+			args[i] = fmt.Sprintf(a, state.Pid)
+		}
+	}
+
+	// run ldconfig to ensure the host's ld cache has the nvidia files
+	libPath := filepath.Join(lcowNvidiaMountPath, "lib")
+	ldconfigOut, err := exec.Command("ldconfig", libPath).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run ldconfig in nvidiaPrestartHook with: %v, %v", string(ldconfigOut), err)
+	}
+
+	nvidiaToolPath, err := exec.LookPath(nvidiaToolBinary)
+	if err != nil {
+		return fmt.Errorf("failed to find %v in path: %v", nvidiaToolBinary, err)
+	}
+
+	out, err := exec.Command(nvidiaToolPath, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run nvidia cli tool with: %v, %v", string(out), err)
+	}
+
+	return nil
+}
+
+func logDebugFile() {
+	contents, err := ioutil.ReadFile(nvidiaDebugFilePath)
+	if err != nil {
+		logrus.Errorf("failed to read nvidia-container-cli debug file: %s", err)
+		return
+	}
+	numBytesInContents := len(contents)
+
+	// since we forward logs on windows to etw, limit log size to 8KB to avoid issues
+	maxLogSize := 8000
+	startBytes := 0
+	i := 0
+	for startBytes < numBytesInContents {
+		bytesLeft := len(contents[startBytes:])
+		chunkSize := maxLogSize
+		if bytesLeft < maxLogSize {
+			chunkSize = bytesLeft
+		}
+		stopBytes := startBytes + chunkSize
+		output := string(contents[startBytes:stopBytes])
+		logrus.WithField("output", output).Infof("nvidia-container-cli debug part %d", i)
+		i += 1
+		startBytes += chunkSize
+	}
+
+}
+
+func nvidiaPrestartHookMain() {
+	if err := runHook(); err != nil {
+		logrus.Errorf("error in nvidia prestart hook: %s", err)
+		logDebugFile()
+		os.Exit(-1)
+	}
+	os.Exit(0)
+}


### PR DESCRIPTION
This work sets up the execution of [nvidia-container-cli](https://github.com/NVIDIA/libnvidia-container) as a prestart hook to runc.
* parse container spec options for the gpu device
* build the nvidia-container-cli tool arguments 
* build prestart hook for running nvidia tool
* create new prestart hook binary 
 
Related to https://github.com/microsoft/hcsshim/pull/765