### PR TITLE
gcs: Handle infinite wait timeouts

### DIFF
--- a/service/gcs/bridge/bridge_v2.go
+++ b/service/gcs/bridge/bridge_v2.go
@@ -416,14 +416,18 @@ func (b *Bridge) waitOnProcessV2(r *Request) (_ RequestResponse, err error) {
 	// If we timed out or if we got the exit code. Acknowledge we no longer want to wait.
 	defer close(doneChan)
 
-	t := time.NewTimer(time.Duration(request.TimeoutInMs) * time.Millisecond)
-	defer t.Stop()
+	var tc <-chan time.Time
+	if request.TimeoutInMs != prot.InfiniteWaitTimeout {
+		t := time.NewTimer(time.Duration(request.TimeoutInMs) * time.Millisecond)
+		defer t.Stop()
+		tc = t.C
+	}
 	select {
 	case exitCode := <-exitCodeChan:
 		return &prot.ContainerWaitForProcessResponse{
 			ExitCode: uint32(exitCode),
 		}, nil
-	case <-t.C:
+	case <-tc:
 		return nil, gcserr.NewHresultError(gcserr.HvVmcomputeTimeout)
 	}
 }

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -425,11 +425,13 @@ type ContainerResizeConsole struct {
 // response should not be sent until the process has exited.
 type ContainerWaitForProcess struct {
 	MessageBase
-	ProcessID uint32 `json:"ProcessId"`
-	// TimeoutInMs is currently ignored, since timeouts are handled on the host
-	// side.
+	ProcessID   uint32 `json:"ProcessId"`
 	TimeoutInMs uint32
 }
+
+// InfiniteWaitTimeout is the value for ContainerWaitForProcess.TimeoutInMs that
+// indicates that no timeout should be in effect.
+const InfiniteWaitTimeout = 0xffffffff
 
 // ContainerSignalProcess is the message from the HCS specifying to send a
 // signal to the given process.


### PR DESCRIPTION
The timeout value passed in the wait message is supposed to treat
0xffffffff as meaning no timeout (as in the Win32 API
WaitForSingleObject). Without this special handling, process waits
will expire after 49 days.