### PR TITLE
Terminate all other container processes when the init exits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ service/pkg/
 bin/*
 rootfs/*
 *.o
+/build/
 
 deps/*
 out/*

--- a/internal/runtime/hcsv2/process.go
+++ b/internal/runtime/hcsv2/process.go
@@ -50,7 +50,9 @@ type containerProcess struct {
 
 	// This is only valid post the exitWg
 	exitCode int
-	exitWg   sync.WaitGroup
+	// exitWg is marked as done as soon as the underlying
+	// (runtime.Process).Wait() call returns, and exitCode has been updated.
+	exitWg sync.WaitGroup
 
 	// Used to allow addtion/removal to the writersWg after an initial wait has
 	// already been issued. It is not safe to call Add/Done without holding this

--- a/service/gcs/stdio/stdio.go
+++ b/service/gcs/stdio/stdio.go
@@ -41,7 +41,8 @@ func (s *ConnectionSet) Close() error {
 	return err
 }
 
-// FileSet contains os.File fields for stdio.
+// FileSet represents the stdio of a process. It contains os.File types for
+// in, out, err.
 type FileSet struct {
 	In, Out, Err *os.File
 }


### PR DESCRIPTION
Previously, if the container init spawned a child process which
inherited its stdio, then exited, gcs would continue waiting until all
child processes terminated. This only occurs when the container does not
have its own pid namespace, as otherwise the kernel terminates all
processes in the namespace automatically. To preserve this semantic even
when the namespace is shared, we now explicitly kill all other container
processes when its init exits.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>