### PR TITLE
Remove dax mount option to avoid 5.4 kernel hard failure

### DIFF
--- a/internal/storage/pmem/pmem.go
+++ b/internal/storage/pmem/pmem.go
@@ -26,7 +26,7 @@ var (
 // automatically cleaned up.
 //
 // Note: For now the platform only supports readonly pmem that is assumed to be
-// `dax`, `ext4`.
+// `ext4`.
 func Mount(ctx context.Context, device uint32, target string) (err error) {
 	_, span := trace.StartSpan(ctx, "pmem::Mount")
 	defer span.End()
@@ -46,7 +46,7 @@ func Mount(ctx context.Context, device uint32, target string) (err error) {
 	}()
 	source := fmt.Sprintf("/dev/pmem%d", device)
 	flags := uintptr(unix.MS_RDONLY)
-	if err := unixMount(source, target, "ext4", flags, "noload,dax"); err != nil {
+	if err := unixMount(source, target, "ext4", flags, "noload"); err != nil {
 		return errors.Wrapf(err, "failed to mount pmem device %s onto %s", source, target)
 	}
 	return nil

--- a/internal/storage/pmem/pmem_test.go
+++ b/internal/storage/pmem/pmem_test.go
@@ -212,7 +212,7 @@ func Test_Mount_Valid_Data(t *testing.T) {
 		return nil
 	}
 	unixMount = func(source string, target string, fstype string, flags uintptr, data string) error {
-		expectedData := "noload,dax"
+		expectedData := "noload"
 		if expectedData != data {
 			t.Errorf("expected data: %s, got: %s", expectedData, data)
 			return errors.New("unexpected data")

--- a/service/gcs/core/gcs/storage.go
+++ b/service/gcs/core/gcs/storage.go
@@ -93,10 +93,7 @@ func (c *gcsCore) getLayerMounts(scratch string, layers []prot.Layer) (scratchMo
 			return nil, nil, err
 		}
 		options := []string{mountOptionNoLoad}
-		if pmem {
-			// PMEM devices support DAX and should use it
-			options = append(options, mountOptionDax)
-		}
+		// TODO (dcantah): Add mountOptionDax when supported.
 		layerMounts[i] = &mountSpec{
 			Source:     deviceName,
 			FileSystem: defaultFileSystem,


### PR DESCRIPTION
* Removed dax mount option to circumvent the 5.4 kernel hard failure on
unsupported dax devices. Previously if the block device wasn't supported
the kernel would simply silently fail. This behavior was changed with this patch
https://patchwork.kernel.org/patch/10631361/.

This change should be reverted whenever dax is properly supported for our
pmem devices.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>