### PR TITLE
Fix pmem build error 

### DIFF
--- a/service/gcs/core/gcs/storage.go
+++ b/service/gcs/core/gcs/storage.go
@@ -88,7 +88,7 @@ func (ms *mountSpec) MountWithTimedRetry(target string) error {
 func (c *gcsCore) getLayerMounts(scratch string, layers []prot.Layer) (scratchMount *mountSpec, layerMounts []*mountSpec, err error) {
 	layerMounts = make([]*mountSpec, len(layers))
 	for i, layer := range layers {
-		deviceName, pmem, err := c.deviceIDToName(layer.Path)
+		deviceName, _, err := c.deviceIDToName(layer.Path)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
* Fix 'pmem declared and not used' build error introduced with https://github.com/microsoft/opengcs/pull/375.
When testing things to solve the 5.4 kernel build failure I had been doing all of
the work on a '54-kernel-failure' branch, so when we discovered the dax issue I
added the fix to this branch and built off of it to verify. When seeing that this
resolved the issue I created a new branch and just added the removing of dax changes
and forgot to add what is in this commit before pushing.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>