### PR TITLE
Fix resolv.conf generation

### DIFF
--- a/internal/runtime/hcsv2/sandbox_container.go
+++ b/internal/runtime/hcsv2/sandbox_container.go
@@ -75,8 +75,12 @@ func setupSandboxContainerSpec(ctx context.Context, id string, spec *oci.Spec) (
 	}
 	var searches, servers []string
 	for _, n := range ns.Adapters() {
-		searches = network.MergeValues(searches, strings.Split(n.DNSSuffix, ","))
-		servers = network.MergeValues(servers, strings.Split(n.DNSServerList, ","))
+		if len(n.DNSSuffix) > 0 {
+			searches = network.MergeValues(searches, strings.Split(n.DNSSuffix, ","))
+		}
+		if len(n.DNSServerList) > 0 {
+			servers = network.MergeValues(servers, strings.Split(n.DNSServerList, ","))
+		}
 	}
 	resolvContent, err := network.GenerateResolvConfContent(ctx, searches, servers, nil)
 	if err != nil {

--- a/internal/runtime/hcsv2/standalone_container.go
+++ b/internal/runtime/hcsv2/standalone_container.go
@@ -95,8 +95,12 @@ func setupStandaloneContainerSpec(ctx context.Context, id string, spec *oci.Spec
 		ns := getOrAddNetworkNamespace(getNetworkNamespaceID(spec))
 		var searches, servers []string
 		for _, n := range ns.Adapters() {
-			servers = network.MergeValues(servers, strings.Split(n.DNSServerList, ","))
-			servers = network.MergeValues(servers, strings.Split(n.DNSServerList, ","))
+			if len(n.DNSSuffix) > 0 {
+				searches = network.MergeValues(searches, strings.Split(n.DNSSuffix, ","))
+			}
+			if len(n.DNSServerList) > 0 {
+				servers = network.MergeValues(servers, strings.Split(n.DNSServerList, ","))
+			}
 		}
 		resolvContent, err := network.GenerateResolvConfContent(ctx, searches, servers, nil)
 		if err != nil {


### PR DESCRIPTION
This change fixes two issues in the resolv.conf generation code:
- If DNSSuffix or DNSServerList are empty strings, the resulting slice
  would contain a single empty string instead of being an empty slice.
  This is due to strings.Split("", ",") returning [""] rather than [].
- The code in standalone_container.go was accidentally not passing a
  value for searches to network.GenerateResolvConfContent.

Signed-off-by: Kevin Parsons <kevpar@microsoft.com>