### PR TITLE
Write 1 to memory.use_hierarchy to enable hierarchy support

### DIFF
--- a/service/gcs/main.go
+++ b/service/gcs/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"syscall"
 	"time"
@@ -182,6 +183,14 @@ func main() {
 	// memory and causing the GCS to malfunction we create two cgroups: gcs,
 	// containers.
 	//
+
+	// Write 1 to memory.use_hierarchy on the root cgroup to enable hierarchy
+	// support. This needs to be set before we create any cgroups as the write
+	// will fail otherwise.
+	if err := ioutil.WriteFile("/sys/fs/cgroup/memory/memory.use_hierarchy", []byte("1"), 0644); err != nil {
+		logrus.WithError(err).Fatal("failed to enable hierarchy support for root cgroup")
+	}
+
 	// The containers cgroup is limited only by {Totalram - 75 MB
 	// (reservation)}.
 	//


### PR DESCRIPTION
`Created nested cgroup for controller "memory" which has incomplete hierarchy support. Nested cgroups may change behavior in the future.
cgroup: "memory" requires setting use_hierarchy to 1 on the root.`

After booting the UVM, this is present in dmesg. There's numerous threads on this over the years from docker, lxc and many others. This should enable the hierarchy support we (believe) we're using for our nested container cgroups so the resource consumptions are properly propagated upwards to their parent cgroup (/containers).`

* Enable hierarchy support so memory usage and limits can flow upwards to the parent cgroup like we'd expect for the /container and its nested cgroups. It's not necessary to set this on any nested cgroups, only the root.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>