### PR TITLE
Support for making multiple overlays in the same scratch path

### DIFF
--- a/internal/storage/overlay/overlay.go
+++ b/internal/storage/overlay/overlay.go
@@ -53,6 +53,11 @@ func Mount(ctx context.Context, layerPaths []string, upperdirPath, workdirPath, 
 
 	options := []string{"lowerdir=" + lowerdir}
 	if upperdirPath != "" {
+		if _, err := os.Stat(upperdirPath); err == nil {
+			// Upperdir already exists. This means we're using the scratch space from
+			// another container. Create a new upper dir with a unique name for this container.
+			upperdirPath += "-" + generateID()
+		}
 		if err := osMkdirAll(upperdirPath, 0755); err != nil {
 			return errors.Wrap(err, "failed to create upper directory in scratch space")
 		}
@@ -64,6 +69,11 @@ func Mount(ctx context.Context, layerPaths []string, upperdirPath, workdirPath, 
 		options = append(options, "upperdir="+upperdirPath)
 	}
 	if workdirPath != "" {
+		if _, err := os.Stat(workdirPath); err == nil {
+			// Workdir already exists. This means we're using the scratch space from
+			// another container. Create a new work dir with a unique name for this container.
+			workdirPath += "-" + generateID()
+		}
 		if err := osMkdirAll(workdirPath, 0755); err != nil {
 			return errors.Wrap(err, "failed to create workdir in scratch space")
 		}

--- a/internal/storage/overlay/util.go
+++ b/internal/storage/overlay/util.go
@@ -1,0 +1,13 @@
+package overlay
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// generateID generates a random unique id.
+func generateID() string {
+	b := make([]byte, 32)
+	rand.Read(b)
+	return hex.EncodeToString(b)
+}


### PR DESCRIPTION
* The work and upper dirs were hardcoded previously so if you had tried to create more than one overlay in a mountpoint (/dev/sda / container scratch volume) it would fail. This change just adds a simple check to see if workdir and upperdir
already exist and will create a unique name for them with a generated ID. This is the same method cri uses to generate container IDs.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>