### PR TITLE
Cleanup process directory after process exits.

### DIFF
--- a/internal/runtime/hcsv2/process.go
+++ b/internal/runtime/hcsv2/process.go
@@ -103,6 +103,13 @@ func newProcess(c *Container, spec *oci.Process, process runtime.Process, pid ui
 		// least one waiter has read the result
 		go func() {
 			p.writersWg.Wait()
+			// cleanup the process state
+			if derr := p.process.Delete(); derr != nil {
+				log.G(ctx).WithFields(logrus.Fields{
+					"cid": p.cid,
+					"pid": p.pid,
+				}).Debugf("process cleanup error: %s", derr)
+			}
 			c.processesMutex.Lock()
 
 			_, span := trace.StartSpan(context.Background(), "newProcess::waitBackground::waitAllWaiters")


### PR DESCRIPTION
Whenever a new process is started inside a container we create a temporary directory for
that process at path `/run/gcsrunc/<container-id>/<pid>` to store some process related
information. However, the v2 workflow of execProcess didn't cleanup these directories when
the process exited. This can cause the tmpfs mounted at the /run to get full for long
running containers. This change adds the change for cleaning up the directories after
process exits.