### PR TITLE
Allow passing any uid for container processes.

### DIFF
--- a/internal/runtime/hcsv2/spec.go
+++ b/internal/runtime/hcsv2/spec.go
@@ -46,10 +46,12 @@ func setProcess(spec *oci.Spec) {
 	}
 }
 
-// setUserStr sets `spec.Process` to the valid `userstr` based on the OCI Image
-// Spec v1.0.0 `userstr`.
+// setUserStr sets `spec.Process` to the valid `userstr` based on the OCI Image Spec
+// v1.0.0 `userstr`.
 //
-// Valid values are: user, uid, user:group, uid:gid, uid:group, user:gid
+// Valid values are: user, uid, user:group, uid:gid, uid:group, user:gid.
+// If uid is provided instead of the username then that value is not checked against the
+// /etc/passwd file to verify if the user with given uid actually exists.
 func setUserStr(spec *oci.Spec, userstr string) error {
 	setProcess(spec)
 
@@ -120,7 +122,8 @@ func setUserID(spec *oci.Spec, uid int) error {
 		return u.Uid == uid
 	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to find user by uid: %d", uid)
+		spec.Process.User.UID, spec.Process.User.GID = uint32(uid), 0
+		return nil
 	}
 	spec.Process.User.UID, spec.Process.User.GID = uint32(u.Uid), uint32(u.Gid)
 	return nil


### PR DESCRIPTION
Usually if a username is provided when starting a process inside the container we look inside the /etc/passwd file of the container to find the uid and gid for that user. However, if a uid is provided instead of a username there is no need to look into the /etc/passwd file to see if that user exists.

This is in accordance with how things are handled in linux as can be seen here: https://github.com/opencontainers/runc/blob/master/libcontainer/user/user.go#L291 (this is called by docker).
In fact in the same function if the user string is passed as `uid:gid` (switch case 2) then we don't look up the uid inside the `/etc/passwd` file.