### PR TITLE
enable device-mapper for mounting container layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ rootfs/*
 
 deps/*
 out/*
+
+.idea/

--- a/internal/runtime/hcsv2/uvm.go
+++ b/internal/runtime/hcsv2/uvm.go
@@ -384,8 +384,14 @@ func modifyMappedDirectory(ctx context.Context, vsock transport.Transport, rt pr
 func modifyMappedVPMemDevice(ctx context.Context, rt prot.ModifyRequestType, vpd *prot.MappedVPMemDeviceV2) (err error) {
 	switch rt {
 	case prot.MreqtAdd:
+		if vpd.MappingInfo != nil {
+			return pmem.MountDM(ctx, vpd.DeviceNumber, vpd.MappingInfo.DeviceOffsetInBytes, vpd.MappingInfo.DeviceSizeInBytes, vpd.MountPath)
+		}
 		return pmem.Mount(ctx, vpd.DeviceNumber, vpd.MountPath)
 	case prot.MreqtRemove:
+		if vpd.MappingInfo != nil {
+			return pmem.UnmountDM(ctx, vpd.DeviceNumber, vpd.MappingInfo.DeviceOffsetInBytes, vpd.MappingInfo.DeviceSizeInBytes, vpd.MountPath)
+		}
 		return storage.UnmountPath(ctx, vpd.MountPath, true)
 	default:
 		return newInvalidRequestTypeError(rt)

--- a/internal/storage/pmem/pmem.go
+++ b/internal/storage/pmem/pmem.go
@@ -8,6 +8,8 @@ import (
 	"os"
 
 	"github.com/Microsoft/opengcs/internal/oc"
+	"github.com/Microsoft/opengcs/internal/storage"
+	dm "github.com/Microsoft/opengcs/internal/storage/devicemapper"
 	"github.com/pkg/errors"
 	"go.opencensus.io/trace"
 	"golang.org/x/sys/unix"
@@ -19,6 +21,28 @@ var (
 	osRemoveAll = os.RemoveAll
 	unixMount   = unix.Mount
 )
+
+const (
+	pMemFmt         = "/dev/pmem%d"
+	linearDeviceFmt = "dm-linear-pmem%d-%d-%d"
+)
+
+func mountInternal(source, target string) (err error) {
+	if err := osMkdirAll(target, 0700); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			osRemoveAll(target)
+		}
+	}()
+
+	flags := uintptr(unix.MS_RDONLY)
+	if err := unixMount(source, target, "ext4", flags, "noload"); err != nil {
+		return errors.Wrapf(err, "failed to mount %s onto %s", source, target)
+	}
+	return nil
+}
 
 // Mount mounts the pmem device at `/dev/pmem<device>` to `target`.
 //
@@ -36,18 +60,53 @@ func Mount(ctx context.Context, device uint32, target string) (err error) {
 		trace.Int64Attribute("device", int64(device)),
 		trace.StringAttribute("target", target))
 
-	if err := osMkdirAll(target, 0700); err != nil {
+	source := fmt.Sprintf(pMemFmt, device)
+	return mountInternal(source, target)
+}
+
+// MountDM creates dm-linear block device and mounts it on `target`
+func MountDM(ctx context.Context, device uint32, deviceStart, deviceSize int64, target string) (err error) {
+	_, span := trace.StartSpan(ctx, "pmem::MountDM")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+
+	lt := dm.PMemLinearTarget(deviceSize, fmt.Sprintf(pMemFmt, device), deviceStart)
+	linearDeviceName := fmt.Sprintf(linearDeviceFmt, device, deviceStart, deviceSize)
+
+	span.AddAttributes(
+		trace.Int64Attribute("device", int64(device)),
+		trace.Int64Attribute("deviceStart", deviceStart),
+		trace.Int64Attribute("sectorSize", deviceSize),
+		trace.StringAttribute("target", target),
+		trace.StringAttribute("table", fmt.Sprintf("%s: '%d %d %s'", linearDeviceName, lt.SectorStart, lt.Length, lt.Params)))
+
+	dmpath, err := dm.CreateDevice(linearDeviceName, dm.CreateReadOnly, []dm.Target{lt})
+	if err != nil {
+		return errors.Wrapf(err, "failed to create dm-linear target: pmem device: %d, offset: %d", device, deviceStart)
+	}
+
+	return mountInternal(dmpath, target)
+}
+
+// UnmountDM unmounts `target` and removes associated dm-linear block device
+func UnmountDM(ctx context.Context, deviceNumber uint32, deviceStart, deviceSize int64, target string) (err error) {
+	_, span := trace.StartSpan(ctx, "pmem::UnmountDM")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+
+	span.AddAttributes(
+		trace.Int64Attribute("device", int64(deviceNumber)),
+		trace.Int64Attribute("deviceStart", deviceStart),
+		trace.Int64Attribute("deviceSize", deviceSize),
+		trace.StringAttribute("target", target))
+
+	if err := storage.UnmountPath(ctx, target, true); err != nil {
 		return err
 	}
-	defer func() {
-		if err != nil {
-			osRemoveAll(target)
-		}
-	}()
-	source := fmt.Sprintf("/dev/pmem%d", device)
-	flags := uintptr(unix.MS_RDONLY)
-	if err := unixMount(source, target, "ext4", flags, "noload"); err != nil {
-		return errors.Wrapf(err, "failed to mount pmem device %s onto %s", source, target)
+
+	linearDeviceName := fmt.Sprintf(linearDeviceFmt, deviceNumber, deviceStart, deviceSize)
+	if err := dm.RemoveDevice(linearDeviceName); err != nil {
+		return errors.Wrapf(err, "failed to remove dm-linear target %s", linearDeviceName)
 	}
 	return nil
 }

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -783,11 +783,19 @@ type MappedDirectoryV2 struct {
 	ReadOnly  bool   `json:",omitempty"`
 }
 
+// DeviceMappingInfo represents a mapped device on a given VPMem
+type DeviceMappingInfo struct {
+	DeviceOffsetInBytes int64 `json:",omitempty"`
+	DeviceSizeInBytes   int64 `json:",omitempty"`
+}
+
 // MappedVPMemDeviceV2 represents a VPMem device that is mapped into a guest
 // path in the V2 schema.
 type MappedVPMemDeviceV2 struct {
 	DeviceNumber uint32 `json:",omitempty"`
 	MountPath    string `json:",omitempty"`
+	// MappingInfo is used when multiple devices are mapped onto a single VPMem device
+	MappingInfo *DeviceMappingInfo `json:",omitempty"`
 }
 
 type MappedVPCIDeviceV2 struct {


### PR DESCRIPTION
Use device mapper to create and mount linear block devices that correspond to container layers
that were mapped onto a single VPMEM device.
The device offset and size are expected to be in bytes and properly aligned

For more context:
https://github.com/microsoft/hcsshim/pull/930 enables mapping multiple LCOW layers
onto a single VPMEM device.

Signed-off-by: Maksim An <maksiman@microsoft.com>