### PR TITLE
Change the update container bridge call to use the modify call instead

### DIFF
--- a/internal/runtime/hcsv2/container.go
+++ b/internal/runtime/hcsv2/container.go
@@ -129,7 +129,7 @@ func (c *Container) Delete(ctx context.Context) error {
 	return c.container.Delete()
 }
 
-func (c *Container) Update(ctx context.Context, resources string) error {
+func (c *Container) Update(ctx context.Context, resources interface{}) error {
 	return c.container.Update(resources)
 }
 
@@ -171,4 +171,8 @@ func (c *Container) GetStats(ctx context.Context) (*v1.Metrics, error) {
 	}
 
 	return cg.Stat(cgroups.IgnoreNotExist)
+}
+
+func (c *Container) modifyContainerConstraints(ctx context.Context, rt prot.ModifyRequestType, cc *prot.ContainerConstraintsV2) (err error) {
+	return c.Update(ctx, cc.Linux)
 }

--- a/service/gcs/bridge/bridge.go
+++ b/service/gcs/bridge/bridge.go
@@ -215,7 +215,6 @@ func (b *Bridge) AssignHandlers(mux *Mux, host *hcsv2.Host) {
 		mux.HandleFunc(prot.ComputeSystemModifySettingsV1, prot.PvV4, b.modifySettingsV2)
 		mux.HandleFunc(prot.ComputeSystemDumpStacksV1, prot.PvV4, b.dumpStacksV2)
 		mux.HandleFunc(prot.ComputeSystemDeleteContainerStateV1, prot.PvV4, b.deleteContainerStateV2)
-		mux.HandleFunc(prot.ComputeSystemUpdateContainerV1, prot.PvV4, b.updateContainerV1)
 	}
 }
 

--- a/service/gcs/runtime/runtime.go
+++ b/service/gcs/runtime/runtime.go
@@ -60,7 +60,7 @@ type Container interface {
 	GetState() (*ContainerState, error)
 	GetRunningProcesses() ([]ContainerProcessState, error)
 	GetAllProcesses() ([]ContainerProcessState, error)
-	Update(resources string) error
+	Update(resources interface{}) error
 }
 
 // Runtime is the interface defining commands over an OCI container runtime,


### PR DESCRIPTION
This PR updates OpenGCS to reuse the `modify` bridge call when issuing a request to update a container. Since the modify call was previously only used if the requested containerID is that of the UVM's pause container (null container ID), this PR additionally updates the code path to allow requests with specific container ID's to issue update calls but prevents them from issuing any host specific settings changes (such as adding a new mapped device in or a VPCI device). 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>