### PR TITLE
Add cifs mount and loopback device modify calls

### DIFF
--- a/internal/storage/cifs/cifs.go
+++ b/internal/storage/cifs/cifs.go
@@ -1,0 +1,102 @@
+package cifs
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/Microsoft/opengcs/internal/network"
+	"github.com/Microsoft/opengcs/internal/oc"
+	"github.com/pkg/errors"
+	"github.com/vishvananda/netns"
+	"go.opencensus.io/trace"
+	"golang.org/x/sys/unix"
+)
+
+const cifsMountOptions = "cache=loose,actimeo=10000,dir_mode=0777,file_mode=0777,sec=ntlmssp,mfsymlinks,ro,async"
+
+var (
+	osMkdirAll  = os.MkdirAll
+	osRemoveAll = os.RemoveAll
+	unixMount   = unix.Mount
+)
+
+// Mount creates a cifs mount at `target`. If `target` doesn't exist this call
+// will try and create it.
+//
+// The UVM generally doesn't have a network adapter in the default network namespace so this function
+// will lock the current goroutines thread, join a network namespace with an available adapter and then
+// perform the mount.
+func Mount(ctx context.Context, source, target, username, password string) (err error) {
+	_, span := trace.StartSpan(ctx, "cifs.Mount")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+
+	span.AddAttributes(
+		trace.StringAttribute("target", target),
+		trace.StringAttribute("source", source))
+
+	if err := osMkdirAll(target, 0700); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			osRemoveAll(target)
+		}
+	}()
+
+	cmd := exec.Command(
+		"mount",
+		"-t",
+		"cifs",
+		source,
+		target,
+		"-o",
+		fmt.Sprintf("vers=3.0,username=%s,password=%s,%s", username, password, cifsMountOptions),
+	)
+
+	pid, err := getNSPid()
+	if err != nil {
+		return errors.Wrap(err, "failed to get network namespace PID to perform cifs mount")
+	}
+
+	// Get a reference to the new network namespace
+	ns, err := netns.GetFromPid(pid)
+	if err != nil {
+		return errors.Wrapf(err, "netns.GetFromPid(%d) failed", pid)
+	}
+	defer ns.Close()
+
+	return network.DoInNetNS(ns, cmd.Run)
+}
+
+// This is gross, there HAS to be a better way
+func getNSPid() (int, error) {
+	data, err := ioutil.ReadFile("/tmp/netnscfg.log")
+	if err != nil {
+		return -1, err
+	}
+
+	subStr := "from PID "
+	netNsStr := string(data)
+	newStr := netNsStr[strings.Index(netNsStr, subStr)+len(subStr):]
+
+	var pidStr string
+	for _, char := range newStr {
+		if !unicode.IsDigit(char) {
+			break
+		}
+		pidStr += string(char)
+	}
+
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return -1, err
+	}
+	return pid, nil
+}

--- a/internal/storage/loopback/loopback.go
+++ b/internal/storage/loopback/loopback.go
@@ -1,0 +1,191 @@
+package loopback
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.opencensus.io/trace"
+	"golang.org/x/sys/unix"
+
+	"github.com/Microsoft/opengcs/internal/log"
+	"github.com/Microsoft/opengcs/internal/oc"
+	"github.com/pkg/errors"
+)
+
+const (
+	EmptyMode         = 0x0
+	LOOP_CTL_ADD      = 0x4c80
+	LOOP_CTL_GET_FREE = 0x4c82
+	LOOP_CTL_REMOVE   = 0x4c81
+	LOOP_CLR_FD       = 0x4c01
+	LOOP_SET_FD       = 0x4c00
+	SYS_IOCTL         = 16
+)
+
+const ext4Options = "noatime,barrier=0,errors=remount-ro,ro"
+
+// Test dependencies
+var (
+	osMkdirAll  = os.MkdirAll
+	osRemoveAll = os.RemoveAll
+	unixMount   = unix.Mount
+)
+
+// Mount mounts `backingFile` as a loopback device on device number `device`. The loopback device
+// is then ext4 mounted at `target`. If `target` doesn't exist it will be created.
+func Mount(ctx context.Context, device int, target, backingFile string) (err error) {
+	_, span := trace.StartSpan(ctx, "loopback.Mount")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+
+	span.AddAttributes(
+		trace.StringAttribute("target", target),
+		trace.Int64Attribute("device", int64(device)),
+		trace.StringAttribute("backingFile", backingFile))
+
+	if err := osMkdirAll(target, 0700); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			osRemoveAll(target)
+		}
+	}()
+
+	// If the device already exists `getLoopID` will return -1, so skip this if the device
+	// we're asking for already exists. The UVM starts with 8 loop devices (0,1,2....7)
+	// already so this should be hit exactly 8 times before we have to actually allocate
+	// a new loop device.
+	loopID := device
+	if _, err := os.Stat(fmt.Sprintf("/dev/loop%d", device)); err != nil {
+		loopCtrl, err := getLoopController(context.Background())
+		if err != nil {
+			return errors.Wrap(err, "failed to get loop controller")
+		}
+
+		// Provision loop device
+		loopID = getLoopID(ctx, loopCtrl, device)
+		if loopID == -1 {
+			return errors.New("failed to provision loop device")
+		}
+	}
+
+	// Pair loop dev with backing file
+	source, err := pairLoopDevice(ctx, loopID, backingFile)
+	if err != nil {
+		return errors.Wrapf(err, "failed to pair backing file %s to loop device with ID %d", backingFile, loopID)
+	}
+
+	return unixMount(source, target, "ext4", uintptr(unix.MS_RDONLY), "noload")
+}
+
+// Teardown a file backed loop device
+func Teardown(ctx context.Context, device int) error {
+	if err := RemoveBackingFile(ctx, device); err != nil {
+		return errors.Wrap(err, "could not teardown loop device")
+	}
+
+	loopCtrl, err := getLoopController(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get loop controller")
+	}
+
+	// remove loop device
+	deallocateLoopDevice(ctx, loopCtrl, device)
+	return nil
+}
+
+func getLoopController(ctx context.Context) (int, error) {
+	// Get loop controller
+	fd, err := safeOpen(ctx, "/dev/loop-control", unix.O_RDWR, EmptyMode)
+	if err != nil {
+		return 0, err
+	}
+	return fd, nil
+}
+
+func getLoopID(ctx context.Context, loopControllerFD, device int) int {
+	loopID, err := allocateLoopDevice(ctx, loopControllerFD, device)
+	if err != nil {
+		return -1
+	}
+	return loopID
+}
+
+// Implement some methods from https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=770fe30a46a12b6fb6b63fbe1737654d28e8484
+/*
+Note: devnr means device number
+Example in C:
+ cfd = open("/dev/loop-control", O_RDWR);
+
+ # add a new specific loop device
+ err = ioctl(cfd, LOOP_CTL_ADD, devnr);
+
+ # remove a specific loop device
+ err = ioctl(cfd, LOOP_CTL_REMOVE, devnr);
+
+ # find or allocate a free loop device to use
+ devnr = ioctl(cfd, LOOP_CTL_GET_FREE);
+
+ sprintf(loopname, "/dev/loop%i", devnr);
+ ffd = open("backing-file", O_RDWR);
+ lfd = open(loopname, O_RDWR);
+ err = ioctl(lfd, LOOP_SET_FD, ffd);
+*/
+
+func allocateLoopDevice(ctx context.Context, loopController, deviceNumber int) (int, error) {
+	device, err := safeIoctl(ctx, loopController, LOOP_CTL_ADD, deviceNumber)
+	if err == unix.EEXIST {
+		return deviceNumber, unix.EEXIST
+	}
+	return int(device), nil
+}
+
+func deallocateLoopDevice(ctx context.Context, loopController, deviceNumber int) int {
+	device, err := safeIoctl(ctx, loopController, LOOP_CTL_REMOVE, deviceNumber)
+	if err == unix.EBUSY {
+		log.G(ctx).WithField("deviceNumber", deviceNumber).Error("loop device is busy")
+		return int(device)
+	}
+
+	log.G(ctx).WithField("deviceNumber", device).Debug("Removed loop device")
+	return int(device)
+}
+
+// PairLoopDevice pairs a backing file `backingFile` to the loop device with device number
+// `deviceNumber`. Returns the loop device path, e.g. "/dev/loop9"
+func pairLoopDevice(ctx context.Context, deviceNumber int, backingFile string) (loopName string, err error) {
+	loopName = fmt.Sprintf("/dev/loop%d", deviceNumber)
+	ffd, err := safeOpen(ctx, backingFile, unix.O_RDONLY, EmptyMode)
+	if err != nil {
+		return "", err
+	}
+	defer unix.Close(ffd)
+
+	lfd, err := safeOpen(ctx, loopName, unix.O_RDONLY, EmptyMode)
+	if err != nil {
+		return "", err
+	}
+	defer unix.Close(lfd)
+
+	_, err = safeIoctl(ctx, lfd, LOOP_SET_FD, ffd)
+	if err != nil {
+		return "", err
+	}
+	return loopName, nil
+}
+
+func RemoveBackingFile(ctx context.Context, deviceNumber int) error {
+	loopName := fmt.Sprintf("/dev/loop%d", deviceNumber)
+	log.G(ctx).WithField("loopName", loopName).Debug("Trying to remove backing file")
+
+	lfd, err := safeOpen(ctx, loopName, unix.O_RDONLY, EmptyMode)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(lfd)
+
+	_, err = safeIoctl(ctx, lfd, LOOP_CLR_FD, 0)
+	return err
+}

--- a/internal/storage/loopback/safe.go
+++ b/internal/storage/loopback/safe.go
@@ -1,0 +1,120 @@
+package loopback
+
+import (
+	"context"
+	"errors"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+type (
+	open struct {
+		path string
+		mode int
+		perm uint32
+	}
+
+	opened struct {
+		open
+		fd int
+	}
+
+	call struct {
+		fd  int
+		req uint
+		val int
+	}
+
+	called struct {
+		call
+		result uintptr
+	}
+)
+
+func safeOpen(ctx context.Context, path string, mode int, perm uint32) (int, error) {
+	const maxAttempts = 20
+	const delay = (5 * time.Second) / maxAttempts
+	file := open{
+		path,
+		mode,
+		perm,
+	}
+
+	process := &opened{
+		file,
+		-1,
+	}
+
+	err := process.Wait(ctx)
+	if err != nil {
+		return -1, err
+	}
+
+	return process.fd, nil
+}
+
+func safeIoctl(ctx context.Context, fd int, req uint, val int) (uintptr, error) {
+	const maxAttempts = 20
+	const delay = (5 * time.Second) / maxAttempts
+	c := call{
+		fd,
+		req,
+		val,
+	}
+
+	process := &called{
+		c,
+		0,
+	}
+
+	err := process.Wait(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	return process.result, nil
+}
+
+func (call *opened) Wait(ctx context.Context) error {
+	if (call.open == open{}) {
+		return errors.New("Open parameters are not set")
+	}
+
+	fd, err := unix.Open(call.path, call.mode, call.perm)
+	if err != nil {
+		return err
+	}
+
+	call.fd = fd
+	return nil
+}
+
+func (c *called) Wait(ctx context.Context) error {
+	if (c.call == call{}) {
+		return errors.New("Syscall parameters are not set")
+	}
+
+	result, errno := ioctl(c.fd, c.req, c.val)
+	if err := isErr(errno); err != nil {
+		return err
+	}
+
+	c.result = result
+	return nil
+}
+
+func ioctl(fd int, req uint, val int) (uintptr, syscall.Errno) {
+	r1, _, errno := unix.Syscall(SYS_IOCTL, uintptr(fd), uintptr(req), uintptr(int32(val)))
+	return r1, errno
+}
+
+func isErr(errno syscall.Errno) error {
+	var err error
+	err = nil
+	if errno != 0 {
+		err = errno
+	}
+	return err
+}

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -513,6 +513,10 @@ const (
 	MrtCombinedLayers = ModifyResourceType("CombinedLayers")
 	// MrtVPMemDevice is the modify resource type for VPMem devices
 	MrtVPMemDevice = ModifyResourceType("VPMemDevice")
+	// MrtLoopbackDevice is the modify resource type for loopback devices
+	MrtLoopbackDevice = ModifyResourceType("LoopbackDevice")
+	// MrtCifsMount is the modify resource type for cifs mounts
+	MrtCifsMount = ModifyResourceType("CifsMount")
 	// MrtNetwork is the modify resource type for the `NetworkAdapterV2` device.
 	MrtNetwork = ModifyResourceType("Network")
 	// MrtVPCIDevice is the modify resource type for vpci devices
@@ -594,6 +598,18 @@ func UnmarshalContainerModifySettings(b []byte) (*ContainerModifySettings, error
 			return &request, errors.Wrap(err, "failed to unmarshal hosted settings as MappedVPMemDeviceV2")
 		}
 		msr.Settings = vpd
+	case MrtLoopbackDevice:
+		lbd := &LoopbackDeviceV2{}
+		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, lbd); err != nil {
+			return &request, errors.Wrap(err, "failed to unmarshal hosted settings as LoopbackDeviceV2")
+		}
+		msr.Settings = lbd
+	case MrtCifsMount:
+		cm := &CifsMountV2{}
+		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, cm); err != nil {
+			return &request, errors.Wrap(err, "failed to unmarshal hosted settings as CifsMountV2")
+		}
+		msr.Settings = cm
 	case MrtCombinedLayers:
 		cl := &CombinedLayersV2{}
 		if err := commonutils.UnmarshalJSONWithHresult(msrRawSettings, cl); err != nil {
@@ -788,6 +804,22 @@ type MappedDirectoryV2 struct {
 type MappedVPMemDeviceV2 struct {
 	DeviceNumber uint32 `json:",omitempty"`
 	MountPath    string `json:",omitempty"`
+}
+
+// LoopbackDeviceV2 represents a loopback device being asked to get created within
+// the guest. This request assumes `BackingFile` exists in the guest.
+type LoopbackDeviceV2 struct {
+	DeviceNumber uint32 `json:",omitempty"`
+	MountPath    string `json:",omitempty"`
+	BackingFile  string `json:",omitempty"`
+}
+
+//CifsMountV2 represents a cifs mount to be mounted in the guest.
+type CifsMountV2 struct {
+	Source    string `json:",omitempty"`
+	MountPath string `json:",omitempty"`
+	Username  string `json:",omitempty"`
+	Password  string `json:",omitempty"`
 }
 
 type MappedVPCIDeviceV2 struct {


### PR DESCRIPTION
To facilitate teleport enabled images from being used for LCOW, add two new modify____
branches for ModifyHostSettings.

* Add cifs mounting logic and associated calls.

* Add loopback device mounting logic and associated calls.

* Add `DoInNetNS` to be able to execute a function inside a specific network namespace. This is
needed as the common LCOW scenario has the only available network adapter not exposed to the
default network namespace. Therefore, to carry out a cifs mount for example, we need to join
this network namespace, perform the action, and then leave on the way out.

Signed-off-by: Daniel Canter <dcanter@microsoft.com>