### PR TITLE
Support passing through arbitrary options and propagation flags for scsi mounts

### DIFF
--- a/internal/runtime/hcsv2/uvm.go
+++ b/internal/runtime/hcsv2/uvm.go
@@ -355,7 +355,7 @@ func modifyMappedVirtualDisk(ctx context.Context, rt prot.ModifyRequestType, mvd
 		mountCtx, cancel := context.WithTimeout(ctx, time.Second*4)
 		defer cancel()
 		if mvd.MountPath != "" {
-			return scsi.Mount(mountCtx, mvd.Controller, mvd.Lun, mvd.MountPath, mvd.ReadOnly)
+			return scsi.Mount(mountCtx, mvd.Controller, mvd.Lun, mvd.MountPath, mvd.ReadOnly, mvd.Options)
 		}
 		return nil
 	case prot.MreqtRemove:

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -759,10 +759,11 @@ type MappedVirtualDisk struct {
 // MappedVirtualDiskV2 represents a disk on the host which is mapped into a
 // directory in the guest in the V2 schema.
 type MappedVirtualDiskV2 struct {
-	MountPath  string `json:",omitempty"`
-	Lun        uint8  `json:",omitempty"`
-	Controller uint8  `json:",omitempty"`
-	ReadOnly   bool   `json:",omitempty"`
+	MountPath  string   `json:",omitempty"`
+	Lun        uint8    `json:",omitempty"`
+	Controller uint8    `json:",omitempty"`
+	ReadOnly   bool     `json:",omitempty"`
+	Options    []string `json:",omitempty"`
 }
 
 // MappedDirectory represents a directory on the host which is mapped to a


### PR DESCRIPTION
This PR fixes the mount propagation behavior for scsi mounts. The expected behavior is that a `rshared` mount propagates mountpoint events from container to host and vice versa. However, since we previously did not create the initial mountpoint for the device in the UVM with the correct propagation flags, events would not flow from the container back to the UVM as expected. This PR fixes this by supporting the ability to pass in arbitrary mount options when attaching a scsi disk. 

Signed-off-by: Kathryn Baldauf <kabaldau@microsoft.com>