### PR TITLE
add support for dm verity target when mounting VPMem devices

### DIFF
--- a/internal/runtime/hcsv2/uvm.go
+++ b/internal/runtime/hcsv2/uvm.go
@@ -384,15 +384,9 @@ func modifyMappedDirectory(ctx context.Context, vsock transport.Transport, rt pr
 func modifyMappedVPMemDevice(ctx context.Context, rt prot.ModifyRequestType, vpd *prot.MappedVPMemDeviceV2) (err error) {
 	switch rt {
 	case prot.MreqtAdd:
-		if vpd.MappingInfo != nil {
-			return pmem.MountDM(ctx, vpd.DeviceNumber, vpd.MappingInfo.DeviceOffsetInBytes, vpd.MappingInfo.DeviceSizeInBytes, vpd.MountPath)
-		}
-		return pmem.Mount(ctx, vpd.DeviceNumber, vpd.MountPath)
+		return pmem.Mount(ctx, vpd.DeviceNumber, vpd.MountPath, vpd.MappingInfo, vpd.VerityInfo)
 	case prot.MreqtRemove:
-		if vpd.MappingInfo != nil {
-			return pmem.UnmountDM(ctx, vpd.DeviceNumber, vpd.MappingInfo.DeviceOffsetInBytes, vpd.MappingInfo.DeviceSizeInBytes, vpd.MountPath)
-		}
-		return storage.UnmountPath(ctx, vpd.MountPath, true)
+		return pmem.Unmount(ctx, vpd.DeviceNumber, vpd.MountPath, vpd.MappingInfo, vpd.VerityInfo)
 	default:
 		return newInvalidRequestTypeError(rt)
 	}

--- a/internal/storage/pmem/pmem.go
+++ b/internal/storage/pmem/pmem.go
@@ -5,6 +5,8 @@ package pmem
 import (
 	"context"
 	"fmt"
+	"github.com/Microsoft/opengcs/internal/log"
+	"github.com/Microsoft/opengcs/service/gcs/prot"
 	"os"
 
 	"github.com/Microsoft/opengcs/internal/oc"
@@ -25,15 +27,19 @@ var (
 const (
 	pMemFmt         = "/dev/pmem%d"
 	linearDeviceFmt = "dm-linear-pmem%d-%d-%d"
+	verityDeviceFmt = "dm-verity-pmem%d-%s"
 )
 
-func mountInternal(source, target string) (err error) {
+// mountInternal mounts source to target via unix.Mount
+func mountInternal(ctx context.Context, source, target string) (err error) {
 	if err := osMkdirAll(target, 0700); err != nil {
 		return err
 	}
 	defer func() {
 		if err != nil {
-			osRemoveAll(target)
+			if err := osRemoveAll(target); err != nil {
+				log.G(ctx).WithError(err).Debugf("error cleaning up target: %s", target)
+			}
 		}
 	}()
 
@@ -44,69 +50,160 @@ func mountInternal(source, target string) (err error) {
 	return nil
 }
 
-// Mount mounts the pmem device at `/dev/pmem<device>` to `target`.
+// Mount mounts the pmem device at `/dev/pmem<device>` to `target` in a basic scenario.
+// If either mappingInfo or verityInfo are non-nil, the device-mapper framework is used
+// to create linear and verity targets accordingly. If both are non-nil, the linear
+// target is created first and used as the data/hash device for the verity target.
 //
 // `target` will be created. On mount failure the created `target` will be
 // automatically cleaned up.
 //
 // Note: For now the platform only supports readonly pmem that is assumed to be
 // `ext4`.
-func Mount(ctx context.Context, device uint32, target string) (err error) {
-	_, span := trace.StartSpan(ctx, "pmem::Mount")
+//
+// Note: both mappingInfo and verityInfo can be non-nil at the same time, in that case
+// linear target is created first and it becomes the data/hash device for verity target.
+func Mount(ctx context.Context, device uint32, target string, mappingInfo *prot.DeviceMappingInfo, verityInfo *prot.DeviceVerityInfo) (err error) {
+	mCtx, span := trace.StartSpan(ctx, "pmem::Mount")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
 	span.AddAttributes(
-		trace.Int64Attribute("device", int64(device)),
+		trace.Int64Attribute("deviceNumber", int64(device)),
 		trace.StringAttribute("target", target))
 
-	source := fmt.Sprintf(pMemFmt, device)
-	return mountInternal(source, target)
-}
-
-// MountDM creates dm-linear block device and mounts it on `target`
-func MountDM(ctx context.Context, device uint32, deviceStart, deviceSize int64, target string) (err error) {
-	_, span := trace.StartSpan(ctx, "pmem::MountDM")
-	defer span.End()
-	defer func() { oc.SetSpanStatus(span, err) }()
-
-	lt := dm.PMemLinearTarget(deviceSize, fmt.Sprintf(pMemFmt, device), deviceStart)
-	linearDeviceName := fmt.Sprintf(linearDeviceFmt, device, deviceStart, deviceSize)
-
-	span.AddAttributes(
-		trace.Int64Attribute("device", int64(device)),
-		trace.Int64Attribute("deviceStart", deviceStart),
-		trace.Int64Attribute("sectorSize", deviceSize),
-		trace.StringAttribute("target", target),
-		trace.StringAttribute("table", fmt.Sprintf("%s: '%d %d %s'", linearDeviceName, lt.SectorStart, lt.Length, lt.Params)))
-
-	dmpath, err := dm.CreateDevice(linearDeviceName, dm.CreateReadOnly, []dm.Target{lt})
-	if err != nil {
-		return errors.Wrapf(err, "failed to create dm-linear target: pmem device: %d, offset: %d", device, deviceStart)
+	devicePath := fmt.Sprintf(pMemFmt, device)
+	// dm linear target has to be created first. when verity info is also present, the linear target becomes the data
+	// device instead of the original VPMem.
+	if mappingInfo != nil {
+		dmLinearName := fmt.Sprintf(linearDeviceFmt, device, mappingInfo.DeviceOffsetInBytes, mappingInfo.DeviceSizeInBytes)
+		if dmLinearPath, err := createDMLinearTarget(mCtx, devicePath, dmLinearName, target, mappingInfo); err != nil {
+			return err
+		} else {
+			devicePath = dmLinearPath
+		}
+		defer func() {
+			if err != nil {
+				if err := dm.RemoveDevice(dmLinearName); err != nil {
+					log.G(mCtx).WithError(err).Debugf("failed to cleanup linear target: %s", dmLinearName)
+				}
+			}
+		}()
 	}
 
-	return mountInternal(dmpath, target)
+	if verityInfo != nil {
+		dmVerityName := fmt.Sprintf(verityDeviceFmt, device, verityInfo.RootDigest)
+		if dmVerityPath, err := createDMVerityTarget(mCtx, devicePath, dmVerityName, target, verityInfo); err != nil {
+			return err
+		} else {
+			devicePath = dmVerityPath
+		}
+		defer func() {
+			if err != nil {
+				if err := dm.RemoveDevice(dmVerityName); err != nil {
+					log.G(mCtx).WithError(err).Debugf("failed to cleanup verity target: %s", dmVerityName)
+				}
+			}
+		}()
+	}
+
+	return mountInternal(mCtx, devicePath, target)
 }
 
-// UnmountDM unmounts `target` and removes associated dm-linear block device
-func UnmountDM(ctx context.Context, deviceNumber uint32, deviceStart, deviceSize int64, target string) (err error) {
-	_, span := trace.StartSpan(ctx, "pmem::UnmountDM")
+// createDMLinearTarget creates dm-linear target from a given `device` slot location and `mappingInfo`
+func createDMLinearTarget(ctx context.Context, devPath, devName string, target string, mappingInfo *prot.DeviceMappingInfo) (_ string, err error) {
+	_, span := trace.StartSpan(ctx, "pmem::createDMLinearTarget")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+
+	linearTarget := dm.PMemLinearTarget(mappingInfo.DeviceSizeInBytes, devPath, mappingInfo.DeviceOffsetInBytes)
+
+	span.AddAttributes(
+		trace.StringAttribute("devicePath", devPath),
+		trace.Int64Attribute("deviceStart", mappingInfo.DeviceOffsetInBytes),
+		trace.Int64Attribute("sectorSize", mappingInfo.DeviceSizeInBytes),
+		trace.StringAttribute("target", target),
+		trace.StringAttribute("linearTable", fmt.Sprintf("%s: '%d %d %s'", devName, linearTarget.SectorStart, linearTarget.LengthInBlocks, linearTarget.Params)))
+
+	devMapperPath, err := dm.CreateDevice(devName, dm.CreateReadOnly, []dm.Target{linearTarget})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create dm-linear target: pmem device: %s, offset: %d", devPath, mappingInfo.DeviceOffsetInBytes)
+	}
+
+	return devMapperPath, nil
+}
+
+// createDMVerityTarget creates a dm-verity target for a given device and mounts that target instead of the device itself
+//
+// verity target table
+// 0 417792 verity 1 /dev/sdb /dev/sdc 4096 4096 52224 1 sha256 2aa4f7b7b6...f4952060e8 762307f4bc8...d2a6b7595d8..
+// |    |     |    |     |     |        |    |    |    |    |              |                        |
+// start|     |    |  data_dev |  data_block | #blocks | hash_alg      root_digest                salt
+//     size   |  version    hash_dev         |     hash_offset
+//          target                       hash_block
+func createDMVerityTarget(ctx context.Context, devPath, devName, target string, verityInfo *prot.DeviceVerityInfo) (_ string, err error) {
+	_, span := trace.StartSpan(ctx, "pmem::createDMVerityTarget")
+	defer span.End()
+	defer func() { oc.SetSpanStatus(span, err) }()
+
+	dmBlocks := verityInfo.Ext4SizeInBytes / dm.BlockSize
+	dataBlocks := verityInfo.Ext4SizeInBytes / int64(verityInfo.BlockSize)
+	hashOffsetBlocks := dataBlocks
+	if verityInfo.SuperBlock {
+		hashOffsetBlocks++
+	}
+	hashes := fmt.Sprintf("%s %s %s", verityInfo.Algorithm, verityInfo.RootDigest, verityInfo.Salt)
+	blkInfo := fmt.Sprintf("%d %d %d %d", verityInfo.BlockSize, verityInfo.BlockSize, dataBlocks, hashOffsetBlocks)
+	devices := fmt.Sprintf("%s %s", devPath, devPath)
+
+	verityTarget := dm.Target{
+		SectorStart:    0,
+		LengthInBlocks: dmBlocks,
+		Type:           "verity",
+		Params:         fmt.Sprintf("%d %s %s %s", verityInfo.Version, devices, blkInfo, hashes),
+	}
+
+	span.AddAttributes(
+		trace.StringAttribute("devicePath", devPath),
+		trace.StringAttribute("target", target),
+		trace.Int64Attribute("sectorSize", dmBlocks),
+		trace.StringAttribute("verityTable", verityTarget.Params))
+
+	mapperPath, err := dm.CreateDevice(devName, dm.CreateReadOnly, []dm.Target{verityTarget})
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to create dm-verity target: pmem device: %d", devPath)
+	}
+
+	return mapperPath, nil
+}
+
+// Unmount unmounts `target` and removes corresponding linear and verity targets when needed
+func Unmount(ctx context.Context, devNumber uint32, target string, mappingInfo *prot.DeviceMappingInfo, verityInfo *prot.DeviceVerityInfo) (err error) {
+	_, span := trace.StartSpan(ctx, "pmem::Unmount")
 	defer span.End()
 	defer func() { oc.SetSpanStatus(span, err) }()
 
 	span.AddAttributes(
-		trace.Int64Attribute("device", int64(deviceNumber)),
-		trace.Int64Attribute("deviceStart", deviceStart),
-		trace.Int64Attribute("deviceSize", deviceSize),
+		trace.Int64Attribute("device", int64(devNumber)),
 		trace.StringAttribute("target", target))
 
 	if err := storage.UnmountPath(ctx, target, true); err != nil {
-		return err
+		return errors.Wrapf(err, "failed to unmount target: %s", target)
 	}
 
-	linearDeviceName := fmt.Sprintf(linearDeviceFmt, deviceNumber, deviceStart, deviceSize)
-	if err := dm.RemoveDevice(linearDeviceName); err != nil {
-		return errors.Wrapf(err, "failed to remove dm-linear target %s", linearDeviceName)
+	if verityInfo != nil {
+		dmVerityName := fmt.Sprintf(verityDeviceFmt, devNumber, verityInfo.RootDigest)
+		if err := dm.RemoveDevice(dmVerityName); err != nil {
+			return errors.Wrapf(err, "failed to remove dm verity target: %s", dmVerityName)
+		}
 	}
+
+	if mappingInfo != nil {
+		dmLinearName := fmt.Sprintf(linearDeviceFmt, devNumber, mappingInfo.DeviceOffsetInBytes, mappingInfo.DeviceSizeInBytes)
+		if err := dm.RemoveDevice(dmLinearName); err != nil {
+			return errors.Wrapf(err, "failed to remove dm linear target: %s", dmLinearName)
+		}
+	}
+
 	return nil
 }

--- a/internal/storage/pmem/pmem_test.go
+++ b/internal/storage/pmem/pmem_test.go
@@ -25,8 +25,8 @@ func Test_Mount_Mkdir_Fails_Error(t *testing.T) {
 	osMkdirAll = func(path string, perm os.FileMode) error {
 		return expectedErr
 	}
-	err := Mount(context.Background(), 0, "")
-	if err != expectedErr {
+	err := Mount(context.Background(), 0, "", nil, nil)
+	if errors.Cause(err) != expectedErr {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
 }
@@ -49,7 +49,7 @@ func Test_Mount_Mkdir_ExpectedPath(t *testing.T) {
 		// Fake the mount success
 		return nil
 	}
-	err := Mount(context.Background(), 0, target)
+	err := Mount(context.Background(), 0, target, nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
@@ -73,7 +73,7 @@ func Test_Mount_Mkdir_ExpectedPerm(t *testing.T) {
 		// Fake the mount success
 		return nil
 	}
-	err := Mount(context.Background(), 0, target)
+	err := Mount(context.Background(), 0, target, nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
@@ -100,7 +100,7 @@ func Test_Mount_Calls_RemoveAll_OnMountFailure(t *testing.T) {
 		// Fake the mount failure to test remove is called
 		return expectedErr
 	}
-	err := Mount(context.Background(), 0, target)
+	err := Mount(context.Background(), 0, target, nil, nil)
 	if errors.Cause(err) != expectedErr {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
@@ -127,7 +127,7 @@ func Test_Mount_Valid_Source(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), device, "/fake/path")
+	err := Mount(context.Background(), device, "/fake/path", nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -150,7 +150,7 @@ func Test_Mount_Valid_Target(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, expectedTarget)
+	err := Mount(context.Background(), 0, expectedTarget, nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -173,7 +173,7 @@ func Test_Mount_Valid_FSType(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, "/fake/path")
+	err := Mount(context.Background(), 0, "/fake/path", nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -196,7 +196,7 @@ func Test_Mount_Valid_Flags(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, "/fake/path")
+	err := Mount(context.Background(), 0, "/fake/path", nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -219,7 +219,7 @@ func Test_Mount_Valid_Data(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, "/fake/path")
+	err := Mount(context.Background(), 0, "/fake/path", nil, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}

--- a/service/gcs/prot/protocol.go
+++ b/service/gcs/prot/protocol.go
@@ -789,6 +789,19 @@ type DeviceMappingInfo struct {
 	DeviceSizeInBytes   int64 `json:",omitempty"`
 }
 
+// DeviceVerityInfo represents dm-verity information of a given data device.
+// The assumption is that the hash device is the same as data device with
+// verity data appended in the end.
+type DeviceVerityInfo struct {
+	Ext4SizeInBytes int64
+	Version         int
+	Algorithm       string
+	SuperBlock      bool
+	RootDigest      string
+	Salt            string
+	BlockSize       int
+}
+
 // MappedVPMemDeviceV2 represents a VPMem device that is mapped into a guest
 // path in the V2 schema.
 type MappedVPMemDeviceV2 struct {
@@ -796,6 +809,7 @@ type MappedVPMemDeviceV2 struct {
 	MountPath    string `json:",omitempty"`
 	// MappingInfo is used when multiple devices are mapped onto a single VPMem device
 	MappingInfo *DeviceMappingInfo `json:",omitempty"`
+	VerityInfo  *DeviceVerityInfo  `json:",omitempty"`
 }
 
 type MappedVPCIDeviceV2 struct {


### PR DESCRIPTION
Update VPMem mount APIs to support passing dm verity information
in addition to VPMem multi-mapping.

Hash device is expected to be the same as the data device with
hash tree appended right after the ext4 file system data, block
sizes for data and hash devices are expected to be the same as
well.

Additionally handle a case when both multi-mapping and verity
are enabled, in that case, first create dm-linear target and use
that target as a data and hash device for dm-verity target.

Signed-off-by: Maksim An <maksiman@microsoft.com>