### PR TITLE
fix wrong type in pmem debug message, pmem and scsi unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ clean:
 
 test:
 	cd $(SRCROOT) && go test ./service/gcsutils/...
+	cd $(SRCROOT) && go test ./...
 	cd $(SRCROOT)/service/gcs && ginkgo -r -keepGoing
 
 out/delta.tar.gz: bin/init bin/vsockexec bin/service/gcs bin/service/gcsutils/gcstools Makefile

--- a/internal/storage/devicemapper/devicemapper_test.go
+++ b/internal/storage/devicemapper/devicemapper_test.go
@@ -79,8 +79,8 @@ func TestCreateError(t *testing.T) {
 		t.Skip()
 	}
 	d, err := createDevice("test-device", 0, []Target{
-		{Type: "error", SectorStart: 0, Length: 1},
-		{Type: "error", SectorStart: 1, Length: 2},
+		{Type: "error", SectorStart: 0, LengthInBlocks: 1},
+		{Type: "error", SectorStart: 1, LengthInBlocks: 2},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -98,8 +98,8 @@ func TestReadOnlyError(t *testing.T) {
 		t.Skip()
 	}
 	d, err := createDevice("test-device", CreateReadOnly, []Target{
-		{Type: "error", SectorStart: 0, Length: 1},
-		{Type: "error", SectorStart: 1, Length: 2},
+		{Type: "error", SectorStart: 0, LengthInBlocks: 1},
+		{Type: "error", SectorStart: 1, LengthInBlocks: 2},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -117,7 +117,7 @@ func TestLinearError(t *testing.T) {
 		t.Skip()
 	}
 	b, err := createDevice("base-device", 0, []Target{
-		{Type: "error", SectorStart: 0, Length: 100},
+		{Type: "error", SectorStart: 0, LengthInBlocks: 100},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/storage/pmem/pmem.go
+++ b/internal/storage/pmem/pmem.go
@@ -171,7 +171,7 @@ func createDMVerityTarget(ctx context.Context, devPath, devName, target string, 
 
 	mapperPath, err := dm.CreateDevice(devName, dm.CreateReadOnly, []dm.Target{verityTarget})
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to create dm-verity target: pmem device: %d", devPath)
+		return "", errors.Wrapf(err, "failed to create dm-verity target: pmem device: %s", devPath)
 	}
 
 	return mapperPath, nil

--- a/internal/storage/scsi/scsi_test.go
+++ b/internal/storage/scsi/scsi_test.go
@@ -25,7 +25,7 @@ func Test_Mount_Mkdir_Fails_Error(t *testing.T) {
 	osMkdirAll = func(path string, perm os.FileMode) error {
 		return expectedErr
 	}
-	err := Mount(context.Background(), 0, 0, "", false)
+	err := Mount(context.Background(), 0, 0, "", false, nil)
 	if err != expectedErr {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
@@ -52,7 +52,7 @@ func Test_Mount_Mkdir_ExpectedPath(t *testing.T) {
 		// Fake the mount success
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, target, false)
+	err := Mount(context.Background(), 0, 0, target, false, nil)
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
@@ -79,7 +79,7 @@ func Test_Mount_Mkdir_ExpectedPerm(t *testing.T) {
 		// Fake the mount success
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, target, false)
+	err := Mount(context.Background(), 0, 0, target, false, nil)
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
@@ -106,7 +106,7 @@ func Test_Mount_ControllerLunToName_Valid_Controller(t *testing.T) {
 		// Fake the mount success
 		return nil
 	}
-	err := Mount(context.Background(), expectedController, 0, "/fake/path", false)
+	err := Mount(context.Background(), expectedController, 0, "/fake/path", false, nil)
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
@@ -133,7 +133,7 @@ func Test_Mount_ControllerLunToName_Valid_Lun(t *testing.T) {
 		// Fake the mount success
 		return nil
 	}
-	err := Mount(context.Background(), 0, expectedLun, "/fake/path", false)
+	err := Mount(context.Background(), 0, expectedLun, "/fake/path", false, nil)
 	if err != nil {
 		t.Fatalf("expected nil error got: %v", err)
 	}
@@ -163,7 +163,7 @@ func Test_Mount_Calls_RemoveAll_OnControllerToLunFailure(t *testing.T) {
 	// NOTE: Do NOT set unixMount because the controller to lun fails. Expect it
 	// not to be called.
 
-	err := Mount(context.Background(), 0, 0, target, false)
+	err := Mount(context.Background(), 0, 0, target, false, nil)
 	if err != expectedErr {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
@@ -196,7 +196,7 @@ func Test_Mount_Calls_RemoveAll_OnMountFailure(t *testing.T) {
 		// Fake the mount failure to test remove is called
 		return expectedErr
 	}
-	err := Mount(context.Background(), 0, 0, target, false)
+	err := Mount(context.Background(), 0, 0, target, false, nil)
 	if err != expectedErr {
 		t.Fatalf("expected err: %v, got: %v", expectedErr, err)
 	}
@@ -225,7 +225,7 @@ func Test_Mount_Valid_Source(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, "/fake/path", false)
+	err := Mount(context.Background(), 0, 0, "/fake/path", false, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -251,7 +251,7 @@ func Test_Mount_Valid_Target(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, expectedTarget, false)
+	err := Mount(context.Background(), 0, 0, expectedTarget, false, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -277,7 +277,7 @@ func Test_Mount_Valid_FSType(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, "/fake/path", false)
+	err := Mount(context.Background(), 0, 0, "/fake/path", false, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -303,7 +303,7 @@ func Test_Mount_Valid_Flags(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, "/fake/path", false)
+	err := Mount(context.Background(), 0, 0, "/fake/path", false, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -329,7 +329,7 @@ func Test_Mount_Readonly_Valid_Flags(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, "/fake/path", true)
+	err := Mount(context.Background(), 0, 0, "/fake/path", true, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -354,7 +354,7 @@ func Test_Mount_Valid_Data(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, "/fake/path", false)
+	err := Mount(context.Background(), 0, 0, "/fake/path", false, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}
@@ -380,7 +380,7 @@ func Test_Mount_Readonly_Valid_Data(t *testing.T) {
 		}
 		return nil
 	}
-	err := Mount(context.Background(), 0, 0, "/fake/path", true)
+	err := Mount(context.Background(), 0, 0, "/fake/path", true, nil)
 	if err != nil {
 		t.Fatalf("expected nil err, got: %v", err)
 	}


### PR DESCRIPTION
one of the debug messages had a wrong type in the message format

unit tests for pmem and scsi were using old structs and method
signatures

Signed-off-by: Maksim An <maksiman@microsoft.com>